### PR TITLE
Update README.md

### DIFF
--- a/events/2019-kubecon-na/README.md
+++ b/events/2019-kubecon-na/README.md
@@ -38,7 +38,7 @@ TBD.
 
 Presentations related to KubeVirt during KubeCon NA 2019:
 
-- [KubeVirt Intro: Virtual Machine Management on Kubernetes](https://sched.co/VnjX) by Chandrakant Jakkidi (F5) and Steve Gordon (Red Hat).
+- [KubeVirt Intro: Virtual Machine Management on Kubernetes](https://sched.co/VyBC) by Chandrakanth Jakkidi (F5) and Steve Gordon (Red Hat).
 - [KubeVirt Deep-Dive: Virtualized GPU workloads on KubeVirt](https://sched.co/VnjX) by David Vossel and Vishesh Tanksale (NVIDIA)
 
 ## KubeVirt demos


### PR DESCRIPTION
sched URL corrected
For both Intro and Deep Dive same Sched URL was mentioned 
Corrected Kubevirt Intro with correct sched URL 
