### PR TITLE
Remove reference to trello

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,4 @@ of options:
 * Chat with us on Slack via <https://kubernetes.slack.com/messages/virtualization> and <https://kubernetes.slack.com/messages/kubevirt-dev>
 * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
 * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
-* Take a glance at [future planning](https://trello.com/b/50CuosoD/kubevirt)
 * Subscribe to [our calendar](https://calendar.google.com/calendar/embed?src=18pc0jur01k8f2cccvn5j04j1g%40group.calendar.google.com&ctz=Etc%2FGMT) or add it to your personal calendar using this calendar ID `18pc0jur01k8f2cccvn5j04j1g@group.calendar.google.com` to stay up to date about upcoming events


### PR DESCRIPTION
The referenced trello board is not being used anymore, so removing that reference

