### PR TITLE
KubevirtCon2021 proposal: Automated migration of Virtual Machines from VMware or OpenStack to KubeVirt

### DIFF
--- a/events/2021-kubevirt-summit/proposals/migrating-vms-to-kubevirt-with-coriolis.md
+++ b/events/2021-kubevirt-summit/proposals/migrating-vms-to-kubevirt-with-coriolis.md
@@ -1,0 +1,37 @@
+# Title
+
+Automated migration of Virtual Michines from VMware or OpenStack to KubeVirt
+
+# Abstract
+
+KubeVirt opens scenarios for a Kubernetes based infrastructure that can handle both VMs and containers.
+Wouldn't it be great to just automatically move all your Virtual Machines from legacy environments
+and consolidate your whole infrastructure around Kubernetes and KubeVirt?
+Coriolis performs automated migrations among most common clouds and virtualization solutions, like
+VMware, OpenStack, AWS, Azure, AzureStack, OCI, Hyper-V and now also KubeVirt.
+
+During this session we will perform a live demo showing how to migrate a VM from VMware vSphere to KubeVirt and
+a separate demo showing the migration of a VM from OpenStack to KubeVirt.
+
+# Presenters
+
+- Alessandro Pilotti, CEO/CTO, Cloudbase Solutions, @cloudbaseit, https://github.com/alexpilotti/
+- Gabriel Samfira, Cloud Architect, Cloudbase Solutions, @gabriel_samfira, https://github.com/gabriel-samfira
+
+
+[X] The presenters agree to abide by the
+    [Linux Foundation's Code of Conduct for Events](https://events.linuxfoundation.org/about/code-of-conduct/)
+
+# Session details
+
+- Track: User
+- Session type: Presentation
+- Duration: 40m
+- Level: Any
+
+# Additional notes
+
+Migrating VMs from VMware to Kubevirt using Coriolis: https://youtu.be/VXJkp31E4jk
+Migrating VMs from OpenStack to Rancher Harvester with Coriolis: https://youtu.be/kzrKyd--g4U
+Coriolis info: https://cloudbase.it/coriolis/
+Coriolis core sources: https://github.com/cloudbase/coriolis


### PR DESCRIPTION
KubeVirt opens scenarios for a Kubernetes based infrastructure that can handle both VMs and containers.
Wouldn't it be great to just automatically move all your Virtual Machines from legacy environments
and consolidate your whole infrastructure around Kubernetes and KubeVirt?
Coriolis performs automated migrations among most common clouds and virtualization solutions, like
VMware, OpenStack, AWS, Azure, AzureStack, OCI, Hyper-V and now also KubeVirt.

During this session we will perform a live demo showing how to migrate a VM from VMware vSphere to KubeVirt and
a separate demo showing the migration of a VM from OpenStack to KubeVirt.
