### PR TITLE
Add information about the KubeVirt v1 session

### DIFF
--- a/events/2021-kubevirt-summit/proposals/the-road-to-v1.md
+++ b/events/2021-kubevirt-summit/proposals/the-road-to-v1.md
@@ -1,0 +1,37 @@
+# Title
+
+The Road to Version 1
+
+# Abstract
+
+A few months ago the KubeVirt community started to discuss what would be the
+requirements that KubeVirt should meet in order to release *KubeVirt Version
+1.0*.
+
+This session aims to:
+
+  - Provide a recap of the discussion so far
+  - Review any relevant updates since the last time the plan was discussed
+  - Collect additional feedback / elements for discussion
+  - Propose the next steps to take
+
+In summary, this session is another step in the journey towards the release
+of KubeVirt Version 1.
+
+# Presenters
+
+- David Vossel, Senior Principal Software Engineer, Red Hat, dvossel@redhat.com
+
+[X] The presenters agree to abide by the
+    [Linux Foundation's Code of Conduct for Events](https://events.linuxfoundation.org/about/code-of-conduct/)
+
+# Session details
+
+- Track: Contributors
+- Session type: Discussion/panel
+- Duration: 20m
+- Level: Any
+
+# Additional notes
+
+


### PR DESCRIPTION
This session is one of the "general interest" sessions planned for the Summit.

As the session program points to the proposal for details, this PR adds a description of that session so it can be linked the same way as the others.