### PR TITLE
Add sigs validator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module kubevirt.io/community
+
+go 1.16
+
+require gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -105,3 +105,4 @@ usergroups:
         teams:
             - name: kubevirt-community
               description: General Discussion
+committees: []

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1,166 +1,107 @@
-# Copied from github.com/kubernetes/community - used for devstats sql generation
 sigs:
-- dir: sig-compute
-  name: compute
-  subprojects:
-  - name: kubevirt
-    owners:
-    - https://raw.githubusercontent.com/kubevirt/k8s-start/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/vAdvisor/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/community/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/kubevirt/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/run/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/libvirt/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/kubevirt-ansible/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/client-python/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/api-reference/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/kubernetes-device-plugins/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/gluster-kubernetes/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/external-storage/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/manageiq-providers-kubevirt/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/v2v-job/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/test-infra-containers/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/storage-demo/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/device-plugin-manager/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/ansible-kubevirt-modules/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/qe-tools/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/vmctl/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/cloud-image-builder/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/common-templates/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/ovs-cni/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/machine-remediation/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/cluster-api-provider-external/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/kubevirt-operator/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/cdi-operator/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/cdi-api-reference/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/cloud-provider-kubevirt/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/cpu-nfd-plugin/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/kubevirt-ssp-operator/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/node-labeller/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/kubevirt-template-validator/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/kvm-info-nfd-plugin/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/node-maintenance-operator/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/bridge-marker/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/kubectl-virt-plugin/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/krew-index/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/must-gather/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/client-go/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/katacoda-scenarios/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/hostpath-provisioner/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/macvtap-cni/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/vm-import-operator/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/secrets/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/ssp-operator/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/csi-driver/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/controller-lifecycle-operator-sdk/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/kubevirt-tekton-tasks/master/OWNERS
-- dir: sig-documentation
-  name: documentation
-  subprojects:
-    - name: documentation
-      owners:
-      - https://raw.githubusercontent.com/kubevirt/demo/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/cockpit-demo/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/user-guide/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/blog/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/kubevirt-tutorial/master/OWNERS
-- dir: sig-storage
-  name: storage
-  subprojects:
-  - name: containerized-data-importer
-    owners:
-    - https://raw.githubusercontent.com/kubevirt/containerized-data-importer/master/OWNERS
-- dir: sig-testing
-  name: testing
-  subprojects:
-  - name: kubevirtci
-    owners:
-    - https://raw.githubusercontent.com/kubevirt/kubevirtci/master/OWNERS
-    - https://raw.githubusercontent.com/kubevirt/project-infra/master/OWNERS
-- dir: sig-virtctl
-  name: virtctl
-  subprojects:
-  - name: kubectl-virt-plugin
-    owners:
-    - https://raw.githubusercontent.com/kubevirt/kubectl-virt-plugin/master/OWNERS
-- dir: sig-virt
-  name: virtblocks
-  subprojects:
-  - name: virtblocks
-    owners:
-    - https://raw.githubusercontent.com/virtblocks/libvirt/master/OWNERS
-    - https://raw.githubusercontent.com/virtblocks/virtblocks/master/OWNERS
-    - https://raw.githubusercontent.com/virtblocks/kubevirt/master/OWNERS
-    - https://raw.githubusercontent.com/virtblocks/closefds/master/OWNERS
-- dir: sig-network
-  name: network
-  subprojects:
-  - name: nmstate
-    owners:
-    - https://raw.githubusercontent.com/nmstate/nmstate/master/OWNERS
-    - https://raw.githubusercontent.com/nmstate/nmstate.github.io/master/OWNERS
-    - https://raw.githubusercontent.com/nmstate/ansible-nmstate/master/OWNERS
-    - https://raw.githubusercontent.com/nmstate/kubernetes-nmstate/master/OWNERS
-  - name: k8snetworkplumbingwg
-    owners:
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/sriov-cni/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/sriov-network-device-plugin/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/multi-net-spec/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/network-attachment-definition-client/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/net-attach-def-admission-controller/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/community/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/k8s-net-attach-def-controller/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/reference-deployment/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/kubemacpool/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/toc/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/network-resources-injector/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/net-service-controller/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/helm-charts/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/multi-networkpolicy/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/multi-networkpolicy-iptables/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/device-info-spec/master/OWNERS
-    - https://raw.githubusercontent.com/k8snetworkplumbingwg/sriov-network-operator/master/OWNERS
-- dir: sig-userinterface
-  name: userinterface
-  subprojects:
-    - name: userinterface
-      owners:
-      - https://raw.githubusercontent.com/kubevirt/cockpit/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/origin-web-console/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/origin-web-console-server/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/web-ui-components/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/web-ui-design/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/web-ui/master/OWNERS
-      - https://raw.githubusercontent.com/kubevirt/web-ui-operator/master/OWNERS
+    - dir: sig-compute
+      name: compute
+      subprojects:
+        - name: kubevirt
+          owners:
+            - https://raw.githubusercontent.com/kubevirt/community/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/libvirt/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/external-storage/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/ansible-kubevirt-modules/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/cloud-image-builder/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/common-templates/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/ovs-cni/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/machine-remediation/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/cluster-api-provider-external/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/cpu-nfd-plugin/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt-ssp-operator/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/node-labeller/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt-template-validator/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kvm-info-nfd-plugin/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/cluster-network-addons-operator/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/node-maintenance-operator/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubectl-virt-plugin/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/krew-index/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/must-gather/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/katacoda-scenarios/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/hostpath-provisioner/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/macvtap-cni/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/ssp-operator/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/csi-driver/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt-tekton-tasks/master/OWNERS
+    - dir: sig-documentation
+      name: documentation
+      subprojects:
+        - name: documentation
+          owners:
+            - https://raw.githubusercontent.com/kubevirt/demo/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/user-guide/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt-tutorial/master/OWNERS
+    - dir: sig-storage
+      name: storage
+      subprojects:
+        - name: containerized-data-importer
+          owners:
+            - https://raw.githubusercontent.com/kubevirt/containerized-data-importer/master/OWNERS
+    - dir: sig-testing
+      name: testing
+      subprojects:
+        - name: kubevirtci
+          owners:
+            - https://raw.githubusercontent.com/kubevirt/kubevirtci/master/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/project-infra/master/OWNERS
+    - dir: sig-virtctl
+      name: virtctl
+      subprojects:
+        - name: kubectl-virt-plugin
+          owners:
+            - https://raw.githubusercontent.com/kubevirt/kubectl-virt-plugin/master/OWNERS
+    - dir: sig-virt
+      name: virtblocks
+      subprojects:
+        - name: virtblocks
+          owners:
+            - https://raw.githubusercontent.com/virtblocks/kubevirt/master/OWNERS
+    - dir: sig-network
+      name: network
+      subprojects:
+        - name: nmstate
+          owners:
+            - https://raw.githubusercontent.com/nmstate/kubernetes-nmstate/master/OWNERS
+        - name: k8snetworkplumbingwg
+          owners:
+            - https://raw.githubusercontent.com/k8snetworkplumbingwg/kubemacpool/master/OWNERS
+            - https://raw.githubusercontent.com/k8snetworkplumbingwg/multi-networkpolicy-iptables/master/OWNERS
+            - https://raw.githubusercontent.com/k8snetworkplumbingwg/sriov-network-operator/master/OWNERS
+    - dir: sig-userinterface
+      name: userinterface
+      subprojects:
+        - name: userinterface
+          owners:
+            - https://raw.githubusercontent.com/kubevirt/web-ui/master/OWNERS
 usergroups:
-- dir: kubevirt-community
-  name: KubeVirt Community
-  mission_statement: >
-    Lorem Ipsum.
-
-  label: kubevirt-community
-  leadership:
-    chairs: []
-#    - github: erikerlandson
-#      name: Erik Erlandson
-#      company: Red Hat
-  meetings:
-  - description: Regular KubeVirt Community Meeting
-    day: Wednesday
-    time: "15:00"
-    tz: UTC
-    frequency: weekly
-    url: https://zoom.us/j/92221936273
-    archive_url: https://docs.google.com/document/d/1kyhpWlEPzZtQJSjJlAqhPcn3t0Mt_o0amhpuNPGs1Ls/edit
-    recordings_url: https://www.youtube.com/watch?v=2Jdb1uJSSs4&list=PLnLpXX8KHIYxs1c4QT0ohCOblKFa6dsIv
-  contact:
-    slack: virtualization
-    mailing_list: https://groups.google.com/forum/#!forum/kubevirt-dev
-    teams:
-    - name: kubevirt-community
-      description: General Discussion
-committees: []
+    - dir: kubevirt-community
+      name: KubeVirt Community
+      mission_statement: |
+        Lorem Ipsum.
+      label: kubevirt-community
+      leadership:
+        chairs: []
+      meetings:
+        - description: Regular KubeVirt Community Meeting
+          day: Wednesday
+          time: "15:00"
+          tz: UTC
+          frequency: weekly
+          url: https://zoom.us/j/92221936273
+          archive_url: https://docs.google.com/document/d/1kyhpWlEPzZtQJSjJlAqhPcn3t0Mt_o0amhpuNPGs1Ls/edit
+          recordings_url: https://www.youtube.com/watch?v=2Jdb1uJSSs4&list=PLnLpXX8KHIYxs1c4QT0ohCOblKFa6dsIv
+      contact:
+        slack: virtualization
+        mailing_list: https://groups.google.com/forum/#!forum/kubevirt-dev
+        teams:
+            - name: kubevirt-community
+              description: General Discussion

--- a/validators/cmd/sigs/README.md
+++ b/validators/cmd/sigs/README.md
@@ -1,0 +1,16 @@
+Validator for sigs.yaml
+=======================
+
+Tool to automatically validate content from [sigs.yaml](../../../sigs.yaml)
+
+Features:
+* Check/remove unreachable owners links
+
+Update sigs.yaml with result from validator
+
+Usage
+-----
+
+```bash
+go run validators/cmd/sigs/sigs-validator.go --sigs_file_path=./sigs.yaml --dry-run=false
+```

--- a/validators/cmd/sigs/sigs-validator.go
+++ b/validators/cmd/sigs/sigs-validator.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+
+	yaml "gopkg.in/yaml.v3"
+
+)
+
+type Sigs struct {
+	Sigs       []*Sig       `yaml:"sigs"`
+	Usergroups []*Usergroup `usergroups:"sigs"`
+}
+
+type Usergroup struct {
+	Dir              string      `yaml:"dir"`
+	Name             string      `yaml:"name"`
+	MissionStatement string      `yaml:"mission_statement"`
+	Label            string      `yaml:"label"`
+	Leadership       *Leadership `yaml:"leadership"`
+	Meetings         []*Meeting  `yaml:"meetings"`
+	Contact          *Contact    `yaml:"contact"`
+}
+
+type Contact struct {
+	Slack       string  `yaml:"slack"`
+	MailingList string  `yaml:"mailing_list"`
+	Teams       []*Team `yaml:"teams"`
+}
+
+type Team struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+type Meeting struct {
+	Description   string `yaml:"description"`
+	Day           string `yaml:"day"`
+	Time          string `yaml:"time"`
+	TZ            string `yaml:"tz"`
+	Frequency     string `yaml:"frequency"`
+	URL           string `yaml:"url"`
+	ArchiveURL    string `yaml:"archive_url"`
+	RecordingsURL string `yaml:"recordings_url"`
+}
+
+type Leadership struct {
+	Chairs []*Chair `yaml:"chairs"`
+}
+
+type Chair struct {
+	Github  string `yaml:"github"`
+	Name    string `yaml:"name"`
+	Company string `yaml:"company"`
+}
+
+type Sig struct {
+	Dir         string         `yaml:"dir"`
+	Name        string         `yaml:"name"`
+	SubProjects []*SubProjects `yaml:"subprojects"`
+}
+
+type SubProjects struct {
+	Name   string   `yaml:"name"`
+	Owners []string `yaml:"owners"`
+}
+
+type options struct {
+	dryRun       bool
+	sigsFilePath string
+}
+
+func (o *options) Validate() error {
+	if o.sigsFilePath == "" {
+		return fmt.Errorf("path to sigs.yaml is required")
+	} else {
+		if _, err := os.Stat(o.sigsFilePath); os.IsNotExist(err) {
+			return fmt.Errorf("file %s does not exist", o.sigsFilePath)
+		}
+	}
+	return nil
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	fs.StringVar(&o.sigsFilePath, "sigs_file_path", "", "File path to the sigs.yaml file to check.")
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func main() {
+	options := gatherOptions()
+	if err := options.Validate(); err != nil {
+		log.Fatalf("invalid arguments: %v", err)
+	}
+	log.Printf("dry-run: %v", options.dryRun)
+
+	buf, err := ioutil.ReadFile(options.sigsFilePath)
+	if err != nil {
+		log.Fatalf("error reading %s: %v", options.sigsFilePath, err)
+	}
+
+	sigs := &Sigs{}
+	err = yaml.Unmarshal(buf, sigs)
+	if err != nil {
+		log.Fatalf("in file %q: %v", options.sigsFilePath, err)
+	}
+
+	for _, sig := range sigs.Sigs {
+		for _, subProject := range sig.SubProjects {
+			log.Printf("checking sig %s subproject %s", sig.Name, subProject.Name)
+			foundOwners := make([]string, 0)
+			for _, ownersFileURL := range subProject.Owners {
+				response, err := http.DefaultClient.Head(ownersFileURL)
+				if err != nil {
+					log.Printf("failed to retrieve %s, continuing with next", ownersFileURL)
+					continue
+				}
+				defer response.Body.Close()
+				if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
+					foundOwners = append(foundOwners, ownersFileURL)
+				} else {
+					log.Printf("failed to retrieve %s", ownersFileURL)
+				}
+			}
+			subProject.Owners = foundOwners
+		}
+	}
+
+	output, err := yaml.Marshal(sigs)
+	if err != nil {
+		log.Fatalf("in file %q: %v", options.sigsFilePath, err)
+	}
+	if options.dryRun {
+		os.Stdout.Write(output)
+	} else {
+		stat, err := os.Stat(options.sigsFilePath)
+		if err != nil {
+			log.Fatalf("file %q: %v", options.sigsFilePath, err)
+		}
+		ioutil.WriteFile(options.sigsFilePath, output, stat.Mode())
+	}
+
+}

--- a/validators/cmd/sigs/sigs-validator.go
+++ b/validators/cmd/sigs/sigs-validator.go
@@ -40,29 +40,29 @@ type Team struct {
 }
 
 type Meeting struct {
-	Description   string `yaml:"description"`
-	Day           string `yaml:"day"`
-	Time          string `yaml:"time"`
-	TZ            string `yaml:"tz"`
-	Frequency     string `yaml:"frequency"`
-	URL           string `yaml:"url"`
+	Description   string
+	Day           string
+	Time          string
+	TZ            string
+	Frequency     string
+	URL           string
 	ArchiveURL    string `yaml:"archive_url"`
 	RecordingsURL string `yaml:"recordings_url"`
 }
 
 type Leadership struct {
-	Chairs []*Chair `yaml:"chairs"`
+	Chairs []*Chair
 }
 
 type Chair struct {
-	Github  string `yaml:"github"`
-	Name    string `yaml:"name"`
-	Company string `yaml:"company"`
+	Github  string
+	Name    string
+	Company string
 }
 
 type SubProjects struct {
-	Name   string   `yaml:"name"`
-	Owners []string `yaml:"owners"`
+	Name   string
+	Owners []string
 }
 
 type options struct {
@@ -73,10 +73,9 @@ type options struct {
 func (o *options) Validate() error {
 	if o.sigsFilePath == "" {
 		return fmt.Errorf("path to sigs.yaml is required")
-	} else {
-		if _, err := os.Stat(o.sigsFilePath); os.IsNotExist(err) {
+	}
+	if _, err := os.Stat(o.sigsFilePath); os.IsNotExist(err) {
 			return fmt.Errorf("file %s does not exist", o.sigsFilePath)
-		}
 	}
 	return nil
 }
@@ -118,14 +117,14 @@ func main() {
 			for _, ownersFileURL := range subProject.Owners {
 				response, err := http.DefaultClient.Head(ownersFileURL)
 				if err != nil {
-					log.Printf("failed to retrieve %s, continuing with next", ownersFileURL)
+					log.Printf("failed to retrieve %q, continuing with next", ownersFileURL)
 					continue
 				}
 				defer response.Body.Close()
 				if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
 					foundOwners = append(foundOwners, ownersFileURL)
 				} else {
-					log.Printf("failed to retrieve %s", ownersFileURL)
+					log.Printf("failed to retrieve %q: %d", ownersFileURL, response.StatusCode)
 				}
 			}
 			subProject.Owners = foundOwners


### PR DESCRIPTION
This PR adds a tool that can validate the basics of the `sigs.yaml` file. Currently it can validate/remove non existing links to owners elements.

Also it updates the sigs.yaml with removed unreachable owners links.

/cc @mazzystr @fabiand @fgimenez 