### PR TITLE
Initial commit for CNCF incubating due diligence

### DIFF
--- a/proposals/governance/incubation_dd.md
+++ b/proposals/governance/incubation_dd.md
@@ -1,72 +1,126 @@
 # KubeVirt Incubation Stage Review Proposal
 
 ## What is KubeVirt: Refresh
+
 KubeVirt technology addresses the needs of development teams that have adopted or want to adopt Kubernetes but possess existing Virtual Machine-based workloads that cannot be easily containerized. More specifically, the technology provides a unified development platform where developers can build, modify, and deploy applications residing in both Application Containers as well as Virtual Machines in a common, shared environment.
 
 Benefits are broad and significant. Teams with a reliance on existing virtual machine-based workloads are empowered to rapidly containerize applications. With virtualized workloads placed directly in development workflows, teams can decompose them over time while still leveraging remaining virtualized components as is comfortably desired.
 
-## Statement on alignment with the CNCF mission:
+## Statement on alignment with the CNCF mission
 
-## Project progress since sandbox
+## Community
 
-## Metrics
+### Governance
 
-### Mailing list
-KubeVirt currently (2021/06/01) has 436 subscribers.  The mailing list typically get 0-5 new threads per day.
+* [Membership policy](https://github.com/kubevirt/community/blob/master/membership_policy.md)
 
-### GitHub
-* 171 official members in the organization
+### SIGs
+
+* [SIG blah](https://github.com/kubevirt/community/blob/master/sigs.yaml)
+
+### Maintainers
+
+*
+*
+*
+
+### GitHub source code repository
+
 * About 50 contributors measured by multiple L or greater sized contributions
-* 96 watched tags
+* Avg of 5 commits per week
+* 171 official members in the organization
 * 2562 stars
 * 615 forks
+* 96 watched tags
 
-### Slack
-Slack channels typically get 0-5 new threads per day.
+### Communications
+The project utilizes Google Groups as a mailing list where where users have a chance to interact with core developers and discuss general topics. There are currently (2021/06/01) 436 subscribers.  The mailing list typically receives 0-5 new threads per day.
 
-### Downloads
+The project holds a video conference every week where users have a chance to interact with core developers, discuss general topics and participate in bug triage. Recently the performance and scale working group started conducting a weekly meeting based on the topic. Both meetings are recorded and posted to the project YouTube channel. Meeting notes are also emailed to the general mailing list to keep the community informed.
+
+The project uses two channels on the CNCF/Kubernetes Slack server. #virtualization is used to handle general use topics. #kubevirt-dev is used for developer oriented topics.  Slack channels typically receive 0-5 new threads per day.
+
+Important announcements are relayed via mailing list, website blog and Twitter.
+
+KubeVirt advertises communications channels via https://kubevirt.io/community as well as project [README](https://github.com/kubevirt/kubevirt/blob/master/README.md).
 
 ### Integrations
-* Kubernetes / minikube
-* Red Hat OKD / OpenShift 4.x
-* oVirt / Red Hat Virtualization
 
-### Community
+* [oVirt](https://www.ovirt.org)
+* [Gardener](https://gardener.cloud/blog/2020-10/00/)
+* [Kubermatic Virtualization](https://www.kubermatic.com/products/kubevirt/)
+* [SUSE/Rancher Harvester](https://github.com/rancher/harvester/blob/766abd06561b059c1af623aacc4e505db471ceee/deploy/charts/harvester/README.md)
+* [Google Anthos](https://youtu.be/RE0A3kHT3LA?t=126)
 
-#### Communications
+### End Users
 
-Kubevirt uses several technologies to maintain the community.
+Project end users are maintained in the [Adopters](https://github.com/kubevirt/kubevirt/blob/main/ADOPTERS.md) files
 
-Source code is stored in git repositories under a GitHub organization provided by the CNCF (https://www.github.com/kubevirt).  GitHub issues are used to track reqs for engineering and bug tracking.  GitHub pull requests are used to peer review contributions.
-
-The project utilizes Google Groups as a mailing list where use, support, proposal topics are discussed.
-
-The project holds a video conference every week via a Zoom account provided by the CNCF.  General topics, support and bug triage are conducted in this meeting.  The project also conducts a weekly meeting based on the topic of performance and scale.  Both meetings are recorded and posted to the project YouTube channel.  Meeting notes are emailed to the general mailing list.
-
-The project uses two channels on the CNCF/Kubernetes Slack server.  #virtualization is used to handle general use and support topics.  #kubevirt-dev is used for developer oriented communication.
-
-KubeVirt utilizes email, website blog and Twitter for important announcements such as version releases.
-
-KubeVirt advertises communications channels via https://kubevirt.io/community as well as project README (https://github.com/kubevirt/kubevirt/blob/master/README.md).
-
-#### End Users
+Significant users include:
+* NVIDIA
+* SUSE
+* Kubermatic
+* H3C
+* CoreWeave
+* Civo
+* CloudFlare
+* Ateme
+* Cloudbase Solutions
 
 ### CNCF Sponsored Security Audit
 
-## Features & Roadmap
+## Product information
 
-### Roadmap at Sandbox
+### Feature design proposals
+Design proposals to allow community members to gain feedback on their designs from the repo approvers before the community member commits to executing on the design. By going through the design process, developers gain a have a high level of confidence that their designs are viable and will be accepted.
+
+* [design-proposals](https://github.com/kubevirt/community/tree/master/design-proposals)
+
+### Release cadence
+
+Kubevirt has a establihed and documented release process and cadence
+
+* [Release process](https://github.com/kubevirt/kubevirt/blob/main/docs/release.md)
+* [Release cadence](https://github.com/kubevirt/kubevirt/blob/main/docs/release.md#cadence-and-timeline)
+
+### Delivered features
+
 * [DONE] GA v1 API for core KubeVirt APIs
  * API v1 features need to rely on GA’ed Kubernetes entities, fully fledged (incl e.g. explain, validation)
  * An OpenAPI definition as the only source of truth for KubeVirt’s API
  * https://github.com/kubevirt/kubevirt/pull/3349
+* [DONE] Zero downtime live updates
 * [DONE] Stabilize or replace bridge network binding
+* [DONE] Disk hotplug
+* [DONE] IPv6 support
+* [DONE] Device passthrough support
+* [DONE] CPU pinning support
+* [DONE] Memory metrics gathering support
+* [DONE] Affinity / Anti-Affinity rules
+* [DONE] Live-Migration support
+* [DONE] Offline disk snapshots
+* [DONE] SRIOV support
+* [DONE] Dynamic SSH Key Injection
+* [DONE] Multus support for multiple network interfaces attached to Virtual Machines
+* [DONE] Dedicated prow deployment for CI functional tests and automation
 
 ### Future Roadmap
+
 * [WIP] Non-root VMI Pods
-* [WIP] Persistent containerDisk volumes
 * [WIP] Establish predictable community release and support patterns
 * [WIP] Define a deprecation policy
 * [WIP] Review and Revise User Guide
-* [WIP] Virt-launcher live updates
 * [WIP] Templating mechanism for VMs
+* [WIP] Monitoring and metrics standardization
+* [WIP] CPU NUMA topology support
+* [WIP] Macvtap support
+* [WIP] SSH proxy ingress support
+
+## Incubation Stage Requirements
+
+The KubeVirt project maintainers propose that KubeVirt move to Incubation based on:
+
+* Use in production by 3 significant end users
+* A healthy number of committers and a growing committer base in addition, to a healthy online community.
+* Demonstrating a substantial ongoing flow of commits and merged contributions that focused on delivering a defined project roadmap and integrations.
+* A clear versioning scheme with dev and stable releases.

--- a/proposals/governance/incubation_dd.md
+++ b/proposals/governance/incubation_dd.md
@@ -8,21 +8,60 @@ Benefits are broad and significant. Teams with a reliance on existing virtual ma
 
 ## Statement on alignment with the CNCF mission
 
+* Project is self-governing
+
+* Is there a documented Code of Conduct that adheres to the CNCF guidelines?
+
+[Kubevirt CoC](https://github.com/kubevirt/kubevirt/blob/main/CODE_OF_CONDUCT.md)
+
+* Does the project have production deployments that are high quality and high-velocity?
+
+Yes. See End Users below.
+
+* Is the project committed to achieving the CNCF principles and do they have a committed roadmap to address any areas of concern raised by the community?
+
+The KubeVirt project exists to aid users in moving from older frameworks to Cloud Native ones.
+
+* Document that the project has a fundamentally sound design without obvious critical compromises that will inhibit potential widespread adoption
+
+KubeVirt is built on top of standardized architectures and interfaces, particularly the Container Runtime Interface and the Libvirt API. Building on top of agreed cloud native and virtualization standards means that KubeVirt remains compatible with many other technologies, not only now but for years to come.
+
+* Document that the project is useful for cloud native deployments & degree that it’s architected in a cloud native style
+
+* Document that the project has an affinity for how CNCF operates and understand the expectation of being a CNCF project.
+
+KubeVirt has been a CNCF project for two years.
+
+## Sandbox Graduation Requirements
+
+* Document that it is being used successfully in production by at least three independent end users which with focus on adequate quality and scope defined.
+
+See End Users Below. Currently 10 organizations use KubeVirt, some of them for internal use (such as CloudFlare and Nvidia) and some incorporate it into products (such as Red Hat and SUSE).
+
+* Have a healthy number of committers. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
+
+* Demonstrate a substantial ongoing flow of commits and merged contributions.
+
+For the last year, KubeVirt has averaged [more than 350 merged PRs per month](https://kubevirt.devstats.cncf.io/d/74/contributions-chart?orgId=1&var-period=m&var-metric=mergedprs&var-repogroup_name=All&var-country_name=All&var-company_name=All&var-company=all) from more than 60 contributors. Of those, [10-20 per month](https://kubevirt.devstats.cncf.io/d/14/new-and-episodic-pr-contributors?orgId=1&from=now-1y&to=now-1w&var-period=m&var-repogroup_name=All) come from new contributors, showing ongoing interest in joining the project.
+
 ## Community
 
 ### Governance
 
+* [WIP Governance](https://github.com/kubevirt/community/pull/123)
 * [Membership policy](https://github.com/kubevirt/community/blob/master/membership_policy.md)
+
+As the project is in the process of growing beyond its initial group of contributors, we are working on adopting additional written governance rules.
 
 ### SIGs
 
-* [SIG yaml](https://github.com/kubevirt/community/blob/master/sigs.yaml)
+* [SIG list](https://github.com/kubevirt/community/blob/master/sigs.yaml)
+
+Most of those SIGs are not yet independent committees. The Performance and Scale SIG has its own leadership and contributors, and both Documentation and Storage SIG should soon have the same. The community plan is to, as the community grows, foster dedicated contributors in each SIG area. As well as expanding our contribution pipeline, this will provide more opportunities for new contributors to rise to leadership of the project.
 
 ### Maintainers
 
-*
-*
-*
+* https://github.com/kubevirt/community/blob/master/MAINTAINERS.md
 
 ### GitHub source code repository
 
@@ -31,7 +70,6 @@ Benefits are broad and significant. Teams with a reliance on existing virtual ma
 * 2562 stars
 * 615 forks
 * 96 watched tags
-* Aprox 40 commits per week avg
 
 ### Communications
 The project utilizes Google Groups as a mailing list where where users have a chance to interact with core developers and discuss general topics. There are currently (2021/06/01) 436 subscribers.  The mailing list typically receives 0-5 new threads per day.
@@ -43,14 +81,6 @@ The project uses two channels on the CNCF Kubernetes Slack server. #virtualizati
 Important announcements are relayed via mailing list, website blog and Twitter.
 
 KubeVirt advertises communications channels via https://kubevirt.io/community as well as project [README](https://github.com/kubevirt/kubevirt/blob/master/README.md).
-
-### Integrations
-
-* [oVirt](https://www.ovirt.org) ... Virtual machines can be run in a container using the external provider feature.
-* [Gardener](https://gardener.cloud/blog/2020-10/00/) ...
-* [Kubermatic Virtualization](https://www.kubermatic.com/products/kubevirt/)
-* [SUSE/Rancher Harvester](https://github.com/rancher/harvester/blob/766abd06561b059c1af623aacc4e505db471ceee/deploy/charts/harvester/README.md)
-* [Google Anthos](https://youtu.be/RE0A3kHT3LA?t=126)
 
 ### End Users
 
@@ -66,6 +96,14 @@ Significant users include:
 * CloudFlare
 * Ateme
 * Cloudbase Solutions
+
+### Integrations
+
+* [oVirt](https://www.ovirt.org) ... Virtual machines can be run in a container using the external provider feature.
+* [Gardener](https://gardener.cloud/blog/2020-10/00/) ...
+* [Kubermatic Virtualization](https://www.kubermatic.com/products/kubevirt/)
+* [SUSE/Rancher Harvester](https://github.com/rancher/harvester/blob/766abd06561b059c1af623aacc4e505db471ceee/deploy/charts/harvester/README.md)
+* [Google Anthos](https://youtu.be/RE0A3kHT3LA?t=126)
 
 ### CNCF Sponsored Security Audit
 

--- a/proposals/governance/incubation_dd.md
+++ b/proposals/governance/incubation_dd.md
@@ -1,6 +1,9 @@
 # KubeVirt Incubation Stage Review Proposal
 
 ## What is KubeVirt: Refresh
+KubeVirt technology addresses the needs of development teams that have adopted or want to adopt Kubernetes but possess existing Virtual Machine-based workloads that cannot be easily containerized. More specifically, the technology provides a unified development platform where developers can build, modify, and deploy applications residing in both Application Containers as well as Virtual Machines in a common, shared environment.
+
+Benefits are broad and significant. Teams with a reliance on existing virtual machine-based workloads are empowered to rapidly containerize applications. With virtualized workloads placed directly in development workflows, teams can decompose them over time while still leveraging remaining virtualized components as is comfortably desired.
 
 ## Statement on alignment with the CNCF mission:
 
@@ -26,4 +29,4 @@
 
 ### Roadmap at Sandbox
 
-### Future Roadmap 
+### Future Roadmap

--- a/proposals/governance/incubation_dd.md
+++ b/proposals/governance/incubation_dd.md
@@ -17,9 +17,23 @@ Benefits are broad and significant. Teams with a reliance on existing virtual ma
 
 ### Integrations
 
-### Community & End Users
+### Community
 
-#### Community
+#### Communications
+
+Kubevirt uses several technologies to maintain the community.
+
+Source code is stored in git repositories under a GitHub organization provided by the CNCF (https://www.github.com/kubevirt).  GitHub issues are used to track reqs for engineering and bug tracking.  GitHub pull requests are used to peer review contributions.
+
+The project utilizes Google Groups as a mailing list where use, support, proposal topics are discussed.
+
+The project holds a video conference every week via a Zoom account provided by the CNCF.  General topics, support and bug triage are conducted in this meeting.  The project also conducts a weekly meeting based on the topic of performance and scale.  Both meetings are recorded and posted to the project YouTube channel.  Meeting notes are emailed to the general mailing list.
+
+The project uses two channels on the CNCF/Kubernetes Slack server.  #virtualization is used to handle general use and support topics.  #kubevirt-dev is used for developer oriented communication.
+
+KubeVirt utilizes email, website blog and Twitter for important announcements such as version releases.
+
+KubeVirt advertises communications channels via https://kubevirt.io/community as well as project README (https://github.com/kubevirt/kubevirt/blob/master/README.md).
 
 #### End Users
 

--- a/proposals/governance/incubation_dd.md
+++ b/proposals/governance/incubation_dd.md
@@ -1,0 +1,29 @@
+# KubeVirt Incubation Stage Review Proposal
+
+## What is KubeVirt: Refresh
+
+## Statement on alignment with the CNCF mission:
+
+## Project progress since sandbox
+
+### Metrics
+
+#### Github
+
+#### Downloads
+
+### Integrations
+
+### Community & End Users
+
+#### Community
+
+#### End Users
+
+### CNCF Sponsored Security Audit
+
+## Features & Roadmap
+
+### Roadmap at Sandbox
+
+### Future Roadmap 

--- a/proposals/governance/incubation_dd.md
+++ b/proposals/governance/incubation_dd.md
@@ -56,5 +56,17 @@ KubeVirt advertises communications channels via https://kubevirt.io/community as
 ## Features & Roadmap
 
 ### Roadmap at Sandbox
+* [DONE] GA v1 API for core KubeVirt APIs
+ * API v1 features need to rely on GA’ed Kubernetes entities, fully fledged (incl e.g. explain, validation)
+ * An OpenAPI definition as the only source of truth for KubeVirt’s API
+ * https://github.com/kubevirt/kubevirt/pull/3349
+* [DONE] Stabilize or replace bridge network binding
 
 ### Future Roadmap
+* [WIP] Non-root VMI Pods
+* [WIP] Persistent containerDisk volumes
+* [WIP] Establish predictable community release and support patterns
+* [WIP] Define a deprecation policy
+* [WIP] Review and Revise User Guide
+* [WIP] Virt-launcher live updates
+* [WIP] Templating mechanism for VMs

--- a/proposals/governance/incubation_dd.md
+++ b/proposals/governance/incubation_dd.md
@@ -27,11 +27,11 @@ Benefits are broad and significant. Teams with a reliance on existing virtual ma
 ### GitHub source code repository
 
 * About 50 contributors measured by multiple L or greater sized contributions
-* Avg of 5 commits per week
 * 171 official members in the organization
 * 2562 stars
 * 615 forks
 * 96 watched tags
+* Aprox 40 commits per week avg
 
 ### Communications
 The project utilizes Google Groups as a mailing list where where users have a chance to interact with core developers and discuss general topics. There are currently (2021/06/01) 436 subscribers.  The mailing list typically receives 0-5 new threads per day.
@@ -90,11 +90,11 @@ Kubevirt has a establihed and documented release process and cadence
  * An OpenAPI definition as the only source of truth for KubeVirt’s API
  * https://github.com/kubevirt/kubevirt/pull/3349
 * [DONE] Zero downtime live updates
-* [DONE] Stabilize or replace bridge network binding
+* [DONE] Stabilize bridge network binding
 * [DONE] Disk hotplug
 * [DONE] IPv6 support
 * [DONE] Device passthrough support
-* [DONE] CPU pinning support
+* [DONE] Numa topology support
 * [DONE] Memory metrics gathering support
 * [DONE] Affinity / Anti-Affinity rules
 * [DONE] Live-Migration support
@@ -112,8 +112,8 @@ Kubevirt has a establihed and documented release process and cadence
 * [WIP] Review and Revise User Guide
 * [WIP] Templating mechanism for VMs
 * [WIP] Monitoring and metrics standardization
+* [WIP] Online Snapshots
 * [WIP] CPU NUMA topology support
-* [WIP] Macvtap support
 * [WIP] SSH proxy ingress support
 
 ## Incubation Stage Requirements

--- a/proposals/governance/incubation_dd.md
+++ b/proposals/governance/incubation_dd.md
@@ -9,13 +9,27 @@ Benefits are broad and significant. Teams with a reliance on existing virtual ma
 
 ## Project progress since sandbox
 
-### Metrics
+## Metrics
 
-#### Github
+### Mailing list
+KubeVirt currently (2021/06/01) has 436 subscribers.  The mailing list typically get 0-5 new threads per day.
 
-#### Downloads
+### GitHub
+* 171 official members in the organization
+* About 50 contributors measured by multiple L or greater sized contributions
+* 96 watched tags
+* 2562 stars
+* 615 forks
+
+### Slack
+Slack channels typically get 0-5 new threads per day.
+
+### Downloads
 
 ### Integrations
+* Kubernetes / minikube
+* Red Hat OKD / OpenShift 4.x
+* oVirt / Red Hat Virtualization
 
 ### Community
 

--- a/proposals/governance/incubation_dd.md
+++ b/proposals/governance/incubation_dd.md
@@ -16,7 +16,7 @@ Benefits are broad and significant. Teams with a reliance on existing virtual ma
 
 ### SIGs
 
-* [SIG blah](https://github.com/kubevirt/community/blob/master/sigs.yaml)
+* [SIG yaml](https://github.com/kubevirt/community/blob/master/sigs.yaml)
 
 ### Maintainers
 
@@ -38,7 +38,7 @@ The project utilizes Google Groups as a mailing list where where users have a ch
 
 The project holds a video conference every week where users have a chance to interact with core developers, discuss general topics and participate in bug triage. Recently the performance and scale working group started conducting a weekly meeting based on the topic. Both meetings are recorded and posted to the project YouTube channel. Meeting notes are also emailed to the general mailing list to keep the community informed.
 
-The project uses two channels on the CNCF/Kubernetes Slack server. #virtualization is used to handle general use topics. #kubevirt-dev is used for developer oriented topics.  Slack channels typically receive 0-5 new threads per day.
+The project uses two channels on the CNCF Kubernetes Slack server. #virtualization is used to handle general use topics. The channel hosts over 1000 users. #kubevirt-dev is used for developer oriented topics. The channel hosts 350 users. The channels typically receive 0-5 new threads per day.
 
 Important announcements are relayed via mailing list, website blog and Twitter.
 
@@ -46,8 +46,8 @@ KubeVirt advertises communications channels via https://kubevirt.io/community as
 
 ### Integrations
 
-* [oVirt](https://www.ovirt.org)
-* [Gardener](https://gardener.cloud/blog/2020-10/00/)
+* [oVirt](https://www.ovirt.org) ... Virtual machines can be run in a container using the external provider feature.
+* [Gardener](https://gardener.cloud/blog/2020-10/00/) ...
 * [Kubermatic Virtualization](https://www.kubermatic.com/products/kubevirt/)
 * [SUSE/Rancher Harvester](https://github.com/rancher/harvester/blob/766abd06561b059c1af623aacc4e505db471ceee/deploy/charts/harvester/README.md)
 * [Google Anthos](https://youtu.be/RE0A3kHT3LA?t=126)
@@ -78,7 +78,7 @@ Design proposals to allow community members to gain feedback on their designs fr
 
 ### Release cadence
 
-Kubevirt has a establihed and documented release process and cadence
+Kubevirt has an established and documented release process and cadence
 
 * [Release process](https://github.com/kubevirt/kubevirt/blob/main/docs/release.md)
 * [Release cadence](https://github.com/kubevirt/kubevirt/blob/main/docs/release.md#cadence-and-timeline)


### PR DESCRIPTION
Initial commit for CNCF incubating due diligence

We will submit this document to [toc/pulls ](https://github.com/cncf/toc/pulls)

Fixes #96 

doc built using accepted due diligence forms from [Falco](https://github.com/cncf/toc/pull/307/files) and [Thanos](https://github.com/cncf/toc/pull/342/files)