### PR TITLE
Approver-led governance for Kubevirt

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,107 @@
+# Project Governance
+
+- [Maintainers](#maintainers)
+- [Becoming a Maintainer](#becoming-a-maintainer)
+- [Meetings](#meetings)
+- [CNCF Resources](#cncf-resources)
+- [Code of Conduct Enforcement](#code-of-conduct)
+- [Voting](#voting)
+
+## Maintainers
+
+KubeVirt Maintainers govern the project. Maintainers collectively manage the 
+project's resources and contributors, and speak for the project in public.  The
+maintainers collectively decide any questions that cannot be resolved at the 
+individual repository level, and provide strategic guidance for the project
+overall.
+
+The current maintainers can be found in [MAINTAINERS](./MAINTAINERS.md).  
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the KubeVirt project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues.
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+## Selecting Maintainers
+
+The current project maintainers will periodically review contributor activities
+to see if additional project members may be promoted to maintainers. 
+
+For nominations, the maintainers will look at the following criteria:
+
+  * Commitment to the project: have they participated in discussions, 
+    contributions, and reviews for 1 year or more?
+  * Does the person show leadership in one of these areas?
+    * Active approver or reviewer in core or subprojects
+    * SIG leadership
+    * Mentoring other project contributors
+  * Does the candidate bring new perspectives or community connections to the 
+    maintainers?
+  * Do they understand how the project works (policies, processes, etc)?
+  * Are they willing to take on the additional duties of a maintainer?
+
+A candidate must be proposed by an existing maintainer by filing an PR in the
+[Community Repo](https://github.com/kubevirt/community) against the MAINTAINERS.md file. 
+A simple majority vote of +1s from existing Maintainers approves the application. 
+Approved maintainers will be added to the [private maintainer mailing list](mailto:cncf-kubevirt-maintainers@lists.cncf.io).
+
+## Meetings
+
+Time zones permitting, Maintainers are expected to participate in the weekly public
+community meeting. 
+
+Maintainers will also have closed meetings in order to discuss security reports
+or Code of Conduct violations.  Such meetings should be scheduled by any
+Maintainer on receipt of a security issue or CoC report.  All current Maintainers
+must be invited to such closed meetings, except for any Maintainer who is
+accused of a CoC violation.
+
+## CNCF Resources
+
+Any Maintainer may suggest a request for CNCF resources, in the
+[developer mailing list](https://groups.google.com/forum/#!forum/kubevirt-dev), 
+the [Maintainer mailing list](mailto:cncf-kubevirt-maintainers@lists.cncf.io), on Github, 
+or during a community meeting.  A simple majority of Maintainers approves the 
+request.  The Maintainers may also choose to delegate working with the CNCF to 
+non-Maintainer community members.
+
+## Code of Conduct
+
+[Code of Conduct](./code-of-conduct.md)
+violations by community members will be discussed and resolved
+on the [private Maintainer mailing list](mailto:cncf-kubevirt-maintainers@lists.cncf.io).  If the reported CoC violator
+is a Maintainer, the Maintainers will instead designate two Maintainers to work
+with CNCF staff in resolving the report.
+
+## Removing Maintainers
+
+Maintainers may voluntarily retire at any time.  Should a maintainer retire, 
+it requires a majority vote of the current maintainers to reinstate them.
+
+Maintainers may also be demoted at any time for one of the following reasons:
+
+* Inactivity, including 6 months or more of non-participation or non-communication,
+* Refusal to abide by this Governance,
+* Violations of the Code of Conduct,
+* Other actions that harm the reputation, stability, or harmony of the Kubevirt
+  project.
+
+Removing a maintainer requires a 2/3 majority vote of the other maintainers.
+
+## Voting
+
+While most business in KubeVirt is conducted by "lazy consensus", periodically
+the Maintainers may need to vote on specific actions or changes.
+A vote can be taken on [the developer mailing list](https://groups.google.com/forum/#!forum/kubevirt-dev) or
+the private Maintainer mailing list for security or conduct matters.  
+Votes may also be taken at the community meeting.  Any Maintainer may
+request a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed. Maintainers
+can be removed by a 2/3 majority vote of all Maintainers, and changes to this
+Governance require a 2/3 vote of all Maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+The current Maintainers Group for the Kubevirt Project consists of:
+
+| Name | Employer | Responsibilities |
+| ----------- | ------- | -------------------------------- |
+| [David Vossel](https://github.com/davidvossel) | Red Hat | |
+| [Vladik Romanovsky](https://github.com/vladikr) | Red Hat | |
+| [Roman Mohr](https://github.com/rmohr) | Red Hat | |
+| [Fabian Deutsch](https://github.com/fabiand) | Red Hat | |
+| [Stu Gott](https://github.com/stu-gott) | Red Hat | |
+| [Vasiliy Ulyanov](https://github.com/vasiliy-ul) | SuSE | |
+| [Chris Calligari](https://github.com/mazzystr) | Red Hat | |
+
+See [the project Governance](GOVERNANCE.md) for how maintainers are selected and replaced.


### PR DESCRIPTION
Creates a GOVERNANCE.md file which outlines a simple self-selecting-council governance format.

This document is based on the CNCF Maintainer governance template.

Updated 6/26, Assumptions made in the new version per @fabiand:

1. ~~"Approver" in our membership docs is equivalent to "Maintainer".~~ Maintainers become a selected position, instead of the group of Approvers to kubevirt/kubevirt
2. CoC violations will be initially reported to the approvers before being escalated to the CNCF.

Unresolved Issues:

1. We need to clean up membership_policy.md so that it reflects our actual process of contributor advancement, particularly the ability to become Approver in a subproject, and that Approver means specifically root-level approver.
2. We also need a private mailing list for the collected Maintainers, as a location to discuss security escalations.

Fixes #97

Signed-off-by: Josh Berkus <josh@agliodbs.com>