### PR TITLE
Add Ryan Hallisey as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,8 @@ The current Maintainers Group for the Kubevirt Project consists of:
 | [Roman Mohr](https://github.com/rmohr) | Red Hat | |
 | [Fabian Deutsch](https://github.com/fabiand) | Red Hat | |
 | [Stu Gott](https://github.com/stu-gott) | Red Hat | |
-| [Vasiliy Ulyanov](https://github.com/vasiliy-ul) | SuSE | |
+| [Vasiliy Ulyanov](https://github.com/vasiliy-ul) | SUSE | |
 | [Chris Calligari](https://github.com/mazzystr) | Red Hat | |
+| [Ryan Hallisey](https://github.com/rthallisey) | Nvidia | |
 
 See [the project Governance](GOVERNANCE.md) for how maintainers are selected and replaced.


### PR DESCRIPTION
* Commitment to the project: have they participated in discussions, 
    contributions, and reviews for 1 year or more?

Ryan is working on various areas in the KubeVirt project since 2018.

 * Does the person show leadership in one of these areas?

Ryan is leading a team of engineers at NVIDIA. He and his team are revealing and fixing issues in KubeVirt around performance and scale on bigger KubeVirt deployments which helps KubeVirt immensely.

He leads SIG performance which helps greatly coordinating performance and scale tasks across the whole projects,.

  * Does the candidate bring new perspectives or community connections to the 
    maintainers?

Yes, he helps a lot organizing efforts around performance and scale, bringing together different parties which can work in a coordinated fashion on these problems.

  * Do they understand how the project works (policies, processes, etc)?

Yes

  * Are they willing to take on the additional duties of a maintainer?

Yes