### PR TITLE
Propose fgimenez as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,7 @@ The current Maintainers Group for the Kubevirt Project consists of:
 | [Vasiliy Ulyanov](https://github.com/vasiliy-ul) | SUSE | |
 | [Chris Calligari](https://github.com/mazzystr) | Red Hat | |
 | [Ryan Hallisey](https://github.com/rthallisey) | Nvidia | |
+| [Federico Gimenez](https://github.com/fgimenez) | Red Hat | CI and Project Infra |
 
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
 


### PR DESCRIPTION
Federico needs to be able to work self-directed with CNCF on various
issues like:
 * DNS
 * Slack integrations
 * Creating issues in the CNCF jira

Criteria check:

> For nominations, the maintainers will look at the following criteria:

>  * Commitment to the project: have they participated in discussions, 
    contributions, and reviews for 1 year or more?

Almost a year. Since December 2020: https://github.com/fgimenez?tab=overview&from=2020-12-01&to=2020-12-31. However I think the amount of contributions and influence is still justifying a nomination. 

>  * Does the person show leadership in one of these areas?

Yes, he leads CI and project infra. Growing our CI needs as well as actively orchestrating identifying and fixing flaky e2e tests in kubevirt/kubevirt.

>    * Active approver or reviewer in core or subprojects

Yes, mostly kubevirt/kubevirt, kubevirt/project-infra and kubevirt/kubevirtci.

>    * SIG leadership
>    * Mentoring other project contributors
>  * Does the candidate bring new perspectives or community connections to the 
    maintainers?

Yes. Mentoring engineers working on flaky e2e tests, as well as guiding community people with different CI needs (SIG scaling, ARM architecture, ...)

>  * Do they understand how the project works (policies, processes, etc)?

Yes. He and @dhiller are creating, maintaining and improving automation around processes an policies for quite some time.

>  * Are they willing to take on the additional duties of a maintainer?

Federico is working on the relevant level for months across the project and I want to give him more liberty to do certain tasks directly without having to go through other maintainers.