### PR TITLE
Add remark for KubeVirt org membership requirements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@
 - [KubeVirt GitHub Org management](./automating-github-org-management.md)
 - CI/CD
     - [Enabling automated merging with tide](./add-merge-automation-to-your-repository.md)
-    - [Prow deployment](https://github.com/kubevirt/project-infra/blob/master/github/ci/prow-deploy/README.md)
-    - [Prow Jobs](https://github.com/kubevirt/project-infra/blob/master/github/ci/prow-deploy/files/jobs/README.md)
-    - [Additional CI/CD services](https://github.com/kubevirt/project-infra/tree/master/github/ci/services)
+    - [Prow deployment](https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/README.md)
+    - [Prow Jobs](https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/files/jobs/README.md)
+    - [Additional CI/CD services](https://github.com/kubevirt/project-infra/tree/main/github/ci/services)
 - [Off-Topic](./off-topic)
     - [Hands on Bazel](./off-topic/how-to-bazel.md)

--- a/docs/automating-github-org-management.md
+++ b/docs/automating-github-org-management.md
@@ -2,6 +2,8 @@
 
 **TLDR; any changes that are applied manually using the GitHub UI will be reverted within one hour! Please file a PR against the [org configuration file]!**
 
+**Contributors applying for KubeVirt org membership: please have a look at the requirements [here](../membership_policy.md#requirements)**
+
 We are using [peribolos] to make transparent and automate management of our GitHub organization, covering members, org and repo settings, teams and access rights of teams to repositories.
 
 Our [org configuration file] contains the settings for our organization. These settings are synchronized by a periodic job.
@@ -23,7 +25,7 @@ Please file a PR against the [org configuration file].
 After the PR is merged changes will be applied within one hour.
 
 Examples:
-* [Adding a github user to the org as member](https://github.com/kubevirt/project-infra/pull/929/files)
+* [Adding a github user to the org as member](https://github.com/kubevirt/project-infra/pull/1765)
 * [Adding a repository and a team, giving the team access to the repository](https://github.com/kubevirt/project-infra/pull/990/files)
 
 [org configuration file]: https://github.com/kubevirt/project-infra/blob/fe7457d449e0d03d5a0dd62359f415b44c3fa323/github/ci/prow/files/orgs.yaml#L1

--- a/member_dd/README.md
+++ b/member_dd/README.md
@@ -1,4 +1,4 @@
 # New Member Due Diligence
 
-* See New Member Policy [here](https://github.com/kubevirt/community/blob/master/membership_policy.md)
-* See New Member Checklist [here](https://github.com/kubevirt/community/blob/master/membership_checklist.md)
+* See New Member Policy [here](../membership_policy.md)
+* See New Member Checklist [here](../membership_checklist.md)


### PR DESCRIPTION
Replaces initial example PR for adding a member to the organization with a proper PR that adheres to the KubeVirt membership onboarding process. Adds a note at the top pointing towards the documentation for that process.

Besides that it fixes a couple of links that pointed to the old default branch name.