### PR TITLE
Update OWNERS: remove Chris and Pep

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,10 @@
 reviewers:
-  - codificat
   - cwilkers
   - jobbler
-  - mazzystr
   - jean-edouard
 
 approvers:
-  - codificat
   - cwilkers
-  - mazzystr
   - fabiand
   - rmohr
 
@@ -21,3 +17,5 @@ emeritus_approvers:
   - iranzo # April 2020
   - ptrnull # April 2020
   - alosadagrande # April 2020
+  - codificat # Jan 2022
+  - mazzystr # Jan 2022


### PR DESCRIPTION
@mazzystr and myself stepped down from community management.

This is to reflect that change in the repo's OWNERS file.

Should we add others?