### PR TITLE
Swap our old CoC for the CNCF CoC,

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -4,38 +4,6 @@ We want to keep the KubeVirt Community a great place to participate, but we need
 
 The KubeVirt community is made up of a diverse mix of individuals using and contributing to all aspects of the project from all over the world, and we want to make sure that the community is a safe and friendly place for everyone.
 
-This code of conduct applies equally to founders, mentors and those seeking help and guidance. It applies to all spaces managed by the KubeVirt project, including IRC, Slack, mailing lists, GitHub, KubeVirt events, and any other forums created by the project team which the community uses for communication.
+As a CNCF project, KubeVirt and its community abide by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-While we have contribution guidelines for specific tools, we expect all members of our community to follow these general guidelines and be accountable to the community. This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
-
-Be Respectful
-----------------
-Our community is defined by the interactions of its members. When people are nice to each other, our community is nice.
-
-It can be easy to forget, in a disconnected world, that behind the IRC nickname or email address there is a person. Please remember that when you communicate with other users, contributors, or anyone outside the community who interacts with us, whether in person or online. A community where people feel uncomfortable or threatened is not a productive one.
-
-Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. For example, when participating in technical discussions, it's important to stay on topic and keep in mind that the discussion is about ideas, concepts, or processes, not about the people behind them.
-
-Be Tolerant
-----------------
-We are a community of professionals, and we conduct ourselves professionally. We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
-
-Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
-
-* Violent threats or language directed against another person
-* Discriminatory jokes and language
-* Posting sexually explicit or violent material
-* Posting (or threatening to post) other people's personally-identifying information ("doxing")
-* Personal insults
-* Unwelcome sexual attention
-* Advocating for, or encouraging, any of the above behaviors
-* Repeatedly participating in any of the above behaviors. In general, if someone asks you to stop, then stop.
-* Resolve Conflicts the Community Way
-
-Disagreements, both social and technical, happen all the time, and KubeVirt is no exception. It is important that we resolve disagreements and differing views constructively and with the help of the community and community processes. When our goals differ dramatically, we encourage the creation of alternative implementations, so that the community can test new ideas and contribute to the discussion.
-
-Nobody knows everything, and nobody is expected to be perfect. Asking questions avoids many problems down the road, and so questions are encouraged. Those who are asked questions should be responsive and helpful. However, when asking a question, care must be taken to do so in an appropriate forum.
-
-If you believe that someone is violating the code of conduct or if you have any questions about the code of conduct, please email the KubeVirt community team and describe the situation or your question as clearly and detailed as possible.
-
-These guidelines are based on the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and are inspired by various other community codes of conduct, in particular the [OpenStack Foundation Community Code of Conduct](https://www.openstack.org/legal/community-code-of-conduct/). License: [CC BY-SA 3.0](https://creativecommons.org/licenses/by/3.0/legalcode).
+Should you encounter a violation of this Code of Conduct, please report it to the [KubeVirt Maintainers private email alias](mailto:cncf-kubevirt-maintainers@cncf.io).  If the CoC violation involves a member of [the Maintainers](https://github.com/kubevirt/community/blob/main/MAINTAINERS.md), please escalate the report to [the CNCF Conduct staff](mailto:conduct@cncf.io).  All reports will be kept confidential.


### PR DESCRIPTION
as requested by the TOC.

This merge must be endorsed by a majority of the KubeVirt Maintainers, since it changes our code of conduct.

Attn: @fabiand @rthallisey @vladikr @rmohr @stu-gott @vasiliy-ul @mazzystr @fgimenez 