### PR TITLE
Correcting the github ID for Andrew Burden

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,7 @@ The current Maintainers Group for the Kubevirt Project consists of:
 | [Stu Gott](https://github.com/stu-gott) | Red Hat | |
 | [Vasiliy Ulyanov](https://github.com/vasiliy-ul) | SUSE | |
 | [Ryan Hallisey](https://github.com/rthallisey) | Nvidia | |
-| [Andrew Burden](https://github.com/aburden) | Red Hat | Community Facilitator |
+| [Andrew Burden](https://github.com/aburdenthehand) | Red Hat | Community Facilitator |
 | [Federico Gimenez](https://github.com/fgimenez) | Red Hat | CI and Project Infra |
 
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).


### PR DESCRIPTION
Signed-off-by: Andrew Burden <aburden@redhat.com>

Correcting the github ID in MAINTAINERS.md from `aburden` to `aburdenthehand`
Once merged, I believe we need to create a PR on the cncf/foundation side so that they are in sync:
https://github.com/cncf/foundation/blob/main/project-maintainers.csv