### PR TITLE
Replacing obsolete calendar links with the calendar owned by KubeVirt

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ of options:
 * Chat with us on Slack via <https://kubernetes.slack.com/messages/virtualization> and <https://kubernetes.slack.com/messages/kubevirt-dev>
 * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
 * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
-* Subscribe to [our calendar](https://calendar.google.com/calendar/embed?src=18pc0jur01k8f2cccvn5j04j1g%40group.calendar.google.com&ctz=Etc%2FGMT) or add it to your personal calendar using this calendar ID `18pc0jur01k8f2cccvn5j04j1g@group.calendar.google.com` to stay up to date about upcoming events
+* Subscribe to [our calendar](https://calendar.google.com/calendar/embed?src=kubevirt@cncf.io) or add it to your personal calendar using this calendar ID `18pc0jur01k8f2cccvn5j04j1g@group.calendar.google.com` to stay up to date about upcoming events

--- a/responsibilities/community_meeting.md
+++ b/responsibilities/community_meeting.md
@@ -8,7 +8,7 @@ At KubeVirt's present scale the community opts to host a weekly meetings for all
   * Link to join is [here](https://zoom.us/j/92221936273)
   * Community organizers will use CNCF/KubeVirt account to host meeting
 
-* When: Every Wednesday @ 16:00 CET/CEST (10:00 EST/EDT) calendar event.  See comm cal [here](https://calendar.google.com/calendar/u/0/embed?src=18pc0jur01k8f2cccvn5j04j1g@group.calendar.google.com&ctz=Etc/GMT)
+* When: Every Wednesday @ 16:00 CET/CEST (10:00 EST/EDT) calendar event. See the community calendar [here](https://calendar.google.com/calendar/u/0/embed?src=kubevirt@cncf.io)
   * Community organizers will start meeting approx 10 mins before start time
   * Community organizers will start recording and begin session at 03 mins past the hour
   * Community organizers will lead the community through the agenda


### PR DESCRIPTION
Thank you @alicefr for raising this. 
The README was pointing to an outdated calendar that wasn't showing any of the weekly meetings. Investigation shows the old link is also in responsibilities/ and in the website repo as well. 

Signed-off-by: Andrew Burden <aburden@redhat.com>