### PR TITLE
Fixed broken link to contributing user guide

### DIFF
--- a/contributors/contributing.md
+++ b/contributors/contributing.md
@@ -3,4 +3,4 @@
 
 The Kubevirt project welcomes all contributors!
 
-Please see [our contribution docs](https://kubevirt.io/user-guide/appendix/contributing/) on how to get started contributing to the project.
+Please see [our contribution docs](https://kubevirt.io/user-guide/contributing/) on how to get started contributing to the project.


### PR DESCRIPTION
**Description:**

Fixes broken link at 
<img width="652" alt="Screenshot 2023-03-13 at 7 54 13 PM" src="https://user-images.githubusercontent.com/23498248/224730179-1fa593cc-e641-4c5e-a79e-0a91007cbbf3.png">

**Broken Link:** https://kubevirt.io/user-guide/appendix/contributing/
**Fixed Link:** https://kubevirt.io/user-guide/contributing/