### PR TITLE
Adding Alona as an approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@ approvers:
   - rmohr
   - davidvossel
   - vladikr
+  - AlonaKaplan
 
 emeritus_approvers:
   - karmab # 10 july 2019


### PR DESCRIPTION
As a long-time kubevirt maintainer, Alona put under scrutiny all the critical network-related PRs proposed to the project in the last 3 years, making sure that new changes are not only technically correct, but that they also don't compromise maintainability of the codebase.

I would like to propose her to become an approver in the community repository as well, so she can take ownership over design proposals. I hope that this will improve our workflow and contributor experience, by discussing high level goals and APIs first, before we get into the weeds of implementation.