### PR TITLE
Add hint to accept org invite for new members

### DIFF
--- a/membership_checklist.md
+++ b/membership_checklist.md
@@ -28,3 +28,6 @@ e.g. (at)example_user
 -
 -
 -
+
+> [!IMPORTANT]
+> After this pull request has been merged, the automation will trigger sending an invitation to the KubeVirt GitHub organization to the new member. The new member needs to accept the invitation to receive member status.

--- a/membership_checklist.md
+++ b/membership_checklist.md
@@ -30,4 +30,4 @@ e.g. (at)example_user
 -
 
 > [!IMPORTANT]
-> After this pull request has been merged, the automation will trigger sending an invitation to the KubeVirt GitHub organization to the new member. The new member needs to accept the invitation to receive member status.
+> After this pull request has been merged, an invitation to the KubeVirt GitHub organization will be automatically sent to the new member. The new member needs to accept the invitation to receive member status.

--- a/membership_policy.md
+++ b/membership_policy.md
@@ -47,6 +47,9 @@ Defined by: Member of the KubeVirt GitHub organization
   * Have your sponsoring org members reply confirmation of sponsorship: +1
   * Once your sponsors have responded, your request will be reviewed by KubeVirt project approvers. Any missing information will be requested.
 
+> [!IMPORTANT]
+> After the pull request against the org members section has been merged (see above), the automation will trigger sending an invitation to the KubeVirt GitHub organization to the new member. The new member needs to accept the invitation to receive member status.
+
 ## Responsibilities and privileges
 
   * Responsive to issues and PRs assigned to them

--- a/membership_policy.md
+++ b/membership_policy.md
@@ -48,7 +48,7 @@ Defined by: Member of the KubeVirt GitHub organization
   * Once your sponsors have responded, your request will be reviewed by KubeVirt project approvers. Any missing information will be requested.
 
 > [!IMPORTANT]
-> After the pull request against the org members section has been merged (see above), the automation will trigger sending an invitation to the KubeVirt GitHub organization to the new member. The new member needs to accept the invitation to receive member status.
+> After the pull request against the org members section has been merged (see above), an invitation to the KubeVirt GitHub organization will be automatically sent to the new member. The new member needs to accept the invitation to receive member status.
 
 ## Responsibilities and privileges
 


### PR DESCRIPTION
Add a hint for new org members that they first need to accept the org invite before they become a full member.

/cc @aburdenthehand @alicefr @fabiand 