### PR TITLE
community, owners: add aburdenthehand as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,17 @@
 reviewers:
+  - aburdenthehand
   - cwilkers
-  - jobbler
   - jean-edouard
+  - jobbler
 
 approvers:
+  - aburdenthehand
+  - AlonaKaplan
   - cwilkers
+  - davidvossel
   - fabiand
   - rmohr
-  - davidvossel
   - vladikr
-  - AlonaKaplan
 
 emeritus_approvers:
   - karmab # 10 july 2019


### PR DESCRIPTION
I think the community manager should be part of the approvers list.

/cc @fabiand @davidvossel @vladikr 