### PR TITLE
SIGs: Remove some SIGs

### DIFF
--- a/hack/generate-devstats-repo-sql.py
+++ b/hack/generate-devstats-repo-sql.py
@@ -175,7 +175,7 @@ def write_repo_groups_sql(k8s_groups, fp):
 
 def main(sigs_yaml, repo_groups_sql):
     with open(sigs_yaml) as fp:
-        k8s_groups = yaml.round_trip_load(fp)
+        k8s_groups = yaml.YAML().load(fp)
 
     if repo_groups_sql is not None:
         with open(repo_groups_sql, 'w') as fp:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -65,12 +65,6 @@ sigs:
             - https://raw.githubusercontent.com/k8snetworkplumbingwg/kubemacpool/master/OWNERS
             - https://raw.githubusercontent.com/k8snetworkplumbingwg/multi-networkpolicy-iptables/master/OWNERS
             - https://raw.githubusercontent.com/k8snetworkplumbingwg/sriov-network-operator/master/OWNERS
-    - dir: sig-userinterface
-      name: userinterface
-      subprojects:
-        - name: userinterface
-          owners:
-            - https://raw.githubusercontent.com/kubevirt/web-ui/main/OWNERS
     - dir: sig-scale
       name: KubeVirt Perf and Scale SIG
       mission_statement: |

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -54,12 +54,6 @@ sigs:
           owners:
             - https://raw.githubusercontent.com/kubevirt/kubevirtci/main/OWNERS
             - https://raw.githubusercontent.com/kubevirt/project-infra/main/OWNERS
-    - dir: sig-virt
-      name: virtblocks
-      subprojects:
-        - name: virtblocks
-          owners:
-            - https://raw.githubusercontent.com/virtblocks/kubevirt/master/OWNERS
     - dir: sig-network
       name: network
       subprojects:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -31,6 +31,7 @@ sigs:
             - https://raw.githubusercontent.com/kubevirt/ssp-operator/master/OWNERS
             - https://raw.githubusercontent.com/kubevirt/csi-driver/master/OWNERS
             - https://raw.githubusercontent.com/kubevirt/kubevirt-tekton-tasks/main/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubectl-virt-plugin/main/OWNERS
     - dir: sig-documentation
       name: documentation
       subprojects:
@@ -53,12 +54,6 @@ sigs:
           owners:
             - https://raw.githubusercontent.com/kubevirt/kubevirtci/main/OWNERS
             - https://raw.githubusercontent.com/kubevirt/project-infra/main/OWNERS
-    - dir: sig-virtctl
-      name: virtctl
-      subprojects:
-        - name: kubectl-virt-plugin
-          owners:
-            - https://raw.githubusercontent.com/kubevirt/kubectl-virt-plugin/main/OWNERS
     - dir: sig-virt
       name: virtblocks
       subprojects:


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove some unusued sigs, focus on the essentials


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
sig-virtctl not in use: https://github.com/search?q=org%3Akubevirt%20sig-virtctl&type=code
sig virt not in use: https://github.com/search?q=org%3Akubevirt%20sig-virt&type=code
sig userinterface not in use: https://github.com/search?q=org%3Akubevirt%20sig-userinterface&type=code

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
