### PR TITLE
enhancements: Propose a more formal yet lean enhancement process

### DIFF
--- a/design-proposals/enhancements.md
+++ b/design-proposals/enhancements.md
@@ -48,6 +48,8 @@ This has a few effects - see the following Goals section.
   in order to make sure that we are able to maintain it
 * As a SIG Approver I want to ensure that a design is sound before a
   VEP Author is approaching an implementation.
+* As a KubeVirt developer, I want to have a single source-of-truth
+  w.r.t. the current status, design API of a feature.
 
 ## Repos
 
@@ -85,7 +87,6 @@ Technical elements:
 None.
 
 ## Scalability
-
 
 Instead of relying on a small approvers pool, now the process starts
 with routing VEPs in the beginning of their life-time to SIGs.

--- a/design-proposals/enhancements.md
+++ b/design-proposals/enhancements.md
@@ -1,0 +1,103 @@
+# Overview
+
+Rework the existing KubeVirt design proposal process into a more
+formal - still lean - Enhancement Porposal process.
+
+## Motivation
+
+Today it's a [very small group](https://github.com/kubevirt/community/blob/main/OWNERS#L7-L14)
+which can approve design-proposals.
+While certain individuals can approve design proposals, once they are merged
+it is not clear who is owning them post-merge.
+
+In this proposal we are proposing to change the process and shape them
+around SIGs.
+At the heart this proposal is requiring
+
+1. designs to be sponsored by a SIG
+2. to make a SIG responsible for the design process (reviews of design, code, documentation)
+3. to make a SIG responsible for managing the design process (collaboration with other SIGs as needed)
+4. to make a SIG owning the feature once it has been merged. The SIG is responsible for maintaing, fixing, running, everything it.
+
+This has a few effects - see the following Goals section.
+
+## Goals
+
+1. The design process now has a mechanism to distribute designs among SIGs
+2. SIG approvers are empowered to approve designs, increase the approvers pool
+3. The ownership of an implemented feature becomes clear
+4. Ensure that designs converge (accept, reject)
+5. Formalize this process as an Virtualization Enhnacement Proposal (VEP) process
+
+## Non Goals
+
+1. Create unnecessary paperwork
+
+## Definition of Users
+
+* VEP Author - The person writing a design/enhancement proposal
+* SIG - A formal KubeVirt SIG
+* SIG Approver - A member of a SIG with approval permissions
+
+## User Stories
+
+* As a VEP Author I want to know who I can work with in order to move
+  my proposal forward
+* As a SIG I want to have a say in what is getting pushed into my domain
+  in order to make sure that we are able to maintain it
+* As a SIG Approver I want to ensure that a design is sound before a
+  VEP Author is approaching an implementation.
+
+## Repos
+
+- https://github.com/kubevirt/enhancements
+
+# Design
+
+Key elements:
+
+- Ownership: SIGs own a freature from it's inception (design) all the way to it's end
+- Approvals: SIG approvers will be allowed to approve designs
+- Responsibilities: SIG Approvers are responsible for driving a design, and connecitng it to other SIGs as needed
+
+Process elements:
+
+- VEP Author creates a GitHub Issue for getting a unique identifier and starting the process
+- VEP Author creates a PR to propose the design targeting a specific SIG
+- SIG decides on an approver to sheppered the VEP
+- SIG collaborates with other SIGs to ensure it's throughly reviewed
+- SIG approves or rejects VEP
+- Other SIG approvers can veto a proposal
+- SIG owns future maintenance of the implementation
+
+Technical elements:
+
+- VEPs will live in a new dedicated repository `kubevirt/enhancements`
+- `OWNER_ALIASES` will be mirrored from kubevirt/kubveirt in order to have the same sigs in the EP repository
+- Approvals and ownership is defined with `OWNERS` files in the `veps/sig-*` directories, tying into the general prow approval and merge flow
+- GitHub Issues will be used to create unique identifiers
+
+## API Examples
+
+None.
+
+## Scalability
+
+
+Instead of relying on a small approvers pool, now the process starts
+with routing VEPs in the beginning of their life-time to SIGs.
+This is expected to increase the time-to-merge-or-reject for VEPs.
+And to distribute the work better.
+
+## Update/Rollback Compatibility
+
+We move back to the community/design-proposals process.
+
+## Functional Testing Approach
+
+Require this process for KubeVirt v1.3+
+
+# Implementation Phases
+
+Beta for KubeVirt v1.3
+GA in KubeVirt v1.4

--- a/design-proposals/enhancements.md
+++ b/design-proposals/enhancements.md
@@ -1,7 +1,7 @@
 # Overview
 
 Rework the existing KubeVirt design proposal process into a more
-formal - still lean - Enhancement Porposal process.
+formal - but still lean - and SIG-aligned Enhancement Proposal process.
 
 ## Motivation
 
@@ -12,12 +12,12 @@ it is not clear who is owning them post-merge.
 
 In this proposal we are proposing to change the process and shape them
 around SIGs.
-At the heart this proposal is requiring
+At its core, this proposal requires:
 
 1. designs to be sponsored by a SIG
-2. to make a SIG responsible for the design process (reviews of design, code, documentation)
-3. to make a SIG responsible for managing the design process (collaboration with other SIGs as needed)
-4. to make a SIG owning the feature once it has been merged. The SIG is responsible for maintaing, fixing, running, everything it.
+2. to make one SIG responsible for the design process (reviews of design, code, documentation)
+3. to make one SIG responsible for managing the design process (collaboration with other SIGs as needed)
+4. to make one SIG to own the feature once it has been merged. The SIG is responsible for maintaining, fixing, running, _everything-it_.
 
 This has a few effects - see the following Goals section.
 
@@ -27,7 +27,7 @@ This has a few effects - see the following Goals section.
 2. SIG approvers are empowered to approve designs, increase the approvers pool
 3. The ownership of an implemented feature becomes clear
 4. Ensure that designs converge (accept, reject)
-5. Formalize this process as an Virtualization Enhnacement Proposal (VEP) process
+5. Formalize this process as an Virtualization Enhancement Proposal (VEP) process
 
 ## Non Goals
 
@@ -56,24 +56,26 @@ This has a few effects - see the following Goals section.
 
 Key elements:
 
-- Ownership: SIGs own a freature from it's inception (design) all the way to it's end
+- Ownership: SIGs own a _feature_ (which includes the process, but also
+  the resulting code) from it's inception (design) all the way (fixes, maintenance) to it's end (removal)[^1]
 - Approvals: SIG approvers will be allowed to approve designs
-- Responsibilities: SIG Approvers are responsible for driving a design, and connecitng it to other SIGs as needed
+- Responsibilities: SIG Approvers are responsible for driving a design, and connecting it to other SIGs as needed
 
 Process elements:
 
 - VEP Author creates a GitHub Issue for getting a unique identifier and starting the process
 - VEP Author creates a PR to propose the design targeting a specific SIG
-- SIG decides on an approver to sheppered the VEP
-- SIG collaborates with other SIGs to ensure it's throughly reviewed
+- SIG decides on an approver to shepherd the VEP
+- SIG collaborates with other SIGs to ensure its thoroughly reviewed
 - SIG approves or rejects VEP
 - Other SIG approvers can veto a proposal
 - SIG owns future maintenance of the implementation
+- KubeVirt Maintainers are responsible to support the owning SIG and VEP author in the case of conflicts and questions
 
 Technical elements:
 
 - VEPs will live in a new dedicated repository `kubevirt/enhancements`
-- `OWNER_ALIASES` will be mirrored from kubevirt/kubveirt in order to have the same sigs in the EP repository
+- `OWNER_ALIASES` will be mirrored from kubevirt/kubevirt in order to have the same SIGs in the EP repository
 - Approvals and ownership is defined with `OWNERS` files in the `veps/sig-*` directories, tying into the general prow approval and merge flow
 - GitHub Issues will be used to create unique identifiers
 
@@ -95,9 +97,11 @@ We move back to the community/design-proposals process.
 
 ## Functional Testing Approach
 
-Require this process for KubeVirt v1.3+
+Require this process for KubeVirt v1.4 and onwards.
 
 # Implementation Phases
 
 Beta for KubeVirt v1.3
 GA in KubeVirt v1.4
+
+[^1]: The exact feature life-cycle is under discussion in https://github.com/kubevirt/community/pull/251. This doc here should be updated once #251 got merged.

--- a/design-proposals/enhancements.md
+++ b/design-proposals/enhancements.md
@@ -12,6 +12,7 @@ it is not clear who is owning them post-merge.
 
 In this proposal we are proposing to change the process and shape them
 around SIGs.
+
 At its core, this proposal requires:
 
 1. designs to be sponsored by a SIG
@@ -101,7 +102,7 @@ Require this process for KubeVirt v1.4 and onwards.
 
 # Implementation Phases
 
-Beta for KubeVirt v1.3
-GA in KubeVirt v1.4
+Beta for KubeVirt v1.4
+GA in KubeVirt v1.5
 
 [^1]: The exact feature life-cycle is under discussion in https://github.com/kubevirt/community/pull/251. This doc here should be updated once #251 got merged.


### PR DESCRIPTION
**What this PR does / why we need it**:

Today it's a [very small group](https://github.com/kubevirt/community/blob/main/OWNERS#L7-L14)
which can approve design-proposals.
While certain individuals can approve design proposals, once they are merged
it is not clear who is owning them post-merge.

In this proposal we are proposing to change the process and shape them
around SIGs.
At the heart this proposal is requiring

1. designs to be sponsored by a SIG
2. to make a SIG responsible for the design process (reviews of design, code, documentation)
3. to make a SIG responsible for managing the design process (collaboration with other SIGs as needed)
4. to make a SIG owning the feature once it has been merged. The SIG is responsible for maintaing, fixing, running, everything it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Please see the "preview" at https://github.com/fabiand/enhancements

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] ~~Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)~~
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] ~~Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test~~
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
