### PR TITLE
Drop feature gate in descheduler support design proposal

### DIFF
--- a/design-proposals/descheduler-support.md
+++ b/design-proposals/descheduler-support.md
@@ -30,21 +30,19 @@ The descheduler should be able to operate on `virt-launcher` pods.
 ## User Stories
 - As a cluster admin running a K8s cluster with a descheduler, I want to deploy and use KubeVirt.
 - As a cluster admin running a K8s cluster with KubeVirt, I want to deploy a descheduler that will correctly operate on my VMs.
-- As a cluster admin I want to enable cluster-wide KubeVirt's descheduler support.
 
 ## Repos
 1. kubevirt/kubevirt
-2. kubevirt/hyperconverged-cluster-operator
 
 # Design
 ## Descheduler Requirements
 1. In order for the descheduler to be able to differentiate `virt-launcher` pods from other pods, all `virt-launcher` pods should be annotated with `descheduler.alpha.kubernetes.io/request-evict-only`.
 2. In cases where the VM will be migrated, eviction requests on `virt-launcher` pods should return 429 HTTP code with a special reason message.
-3. In order for the deschduler to understand that a `virt-launcher` pod is pending migration, it should be annotated with `descheduler.alpha.kubernetes.io/eviction-in-progress` so it will not try to evict it again.
+3. In order for the descheduler to understand that a `virt-launcher` pod is pending migration, it should be annotated with `descheduler.alpha.kubernetes.io/eviction-in-progress` so it will not try to evict it again.
 4. In case the migration failed, the `descheduler.alpha.kubernetes.io/eviction-in-progress` annotation will be removed from the source `virt-launcer` so the descheduler will understand that it could try evicting it again.
 
 ## Feature Gate
-A `DeschedulerSupport` feature gate will be introduced in order to enable this feature.
+A feature gate is not needed.
 
 ## Changes to Pod Eviction Webhook
 Currently, the descheduler observes the one of the following responses:
@@ -87,11 +85,9 @@ The flow will be tested e2e without a real descheduler by manually evicting a `v
 This should be done with all eviction strategies.
 
 # Implementation Phases
-1. Add a feature gate in KubeVirt.
-2. Add the logic to pod eviction webhook.
-3. Add the `descheduler.alpha.kubernetes.io/request-evict-only` annotation to newly created `virt-launcher` pods.
-4. Add the `descheduler.alpha.kubernetes.io/request-evict-only` annotation to existing `virt-launcher` pods that do not have it.
-5. Add the `descheduler.alpha.kubernetes.io/eviction-in-progress` annotation to `virt-launcher` pods that their controlling VMI is marked for eviction.
-6. Remove the `descheduler.alpha.kubernetes.io/eviction-in-progress` annotation to `virt-launcher` pods which failed migration.
-7. Add an E2E test simulating an eviction.
-8. Add an enabler in HCO.
+1. Add the logic to pod eviction webhook.
+2. Add the `descheduler.alpha.kubernetes.io/request-evict-only` annotation to newly created `virt-launcher` pods.
+3. Add the `descheduler.alpha.kubernetes.io/request-evict-only` annotation to existing `virt-launcher` pods that do not have it.
+4. Add the `descheduler.alpha.kubernetes.io/eviction-in-progress` annotation to `virt-launcher` pods that their controlling VMI is marked for eviction.
+5. Remove the `descheduler.alpha.kubernetes.io/eviction-in-progress` annotation to `virt-launcher` pods which failed migration.
+6. Add an E2E test simulating an eviction.


### PR DESCRIPTION
The descheduler support design proposal specifies that a feature gate will be added.
The feature gate can be dropped, since no work is added other than to add annotations.
The feature gate drop also has the advantage of saving work to the cluster admins; with the feature gate, if a cluster admin wants to enable the descheduler, they have to install it and add the feature gate to KubeVirt.
Without the feature gate they only have to install it.

Also, this feature gate only enables a support for the descheduler, which should always be enabled, and there are no advantages to not have it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/cc @acardace @Barakmor1 @iholder101 @jean-edouard @xpivarc 