### PR TITLE
Add kubevirt/kubevirt approvers to this repository's OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,6 +12,15 @@ approvers:
   - fabiand
   - rmohr
   - vladikr
+  - jean-edouard
+  - mhenriks
+  - enp0s3
+  - xpivarc
+  - vasiliy-ul
+  - acardace
+  - alicefr
+  - iholder101
+  - stu-gott
 
 emeritus_approvers:
   - karmab # 10 july 2019


### PR DESCRIPTION
**What this PR does / why we need it**:
This repository lacks approvers, and most of the existing approvers aren't very active anymore.

As Kubevirt becomes more popular and active, and more design proposals are being introduced, we need more people to share the burden of reviewing and approving such proposals. This is especially important since https://github.com/kubevirt/community/pull/251 had landed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
