### PR TITLE
community, wg, arch: add wg, sig subprojects and charter for S390x and ARM

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -152,6 +152,23 @@ sigs:
         - https://raw.githubusercontent.com/kubevirt/kubevirt/main/hack/OWNERS
         - https://raw.githubusercontent.com/kubevirt/kubevirt/main/hack/builder/OWNERS
         - https://raw.githubusercontent.com/kubevirt/kubevirt/main/bazel/OWNERS
+      - name: arch-s390x
+        description: |
+          The arch-s390x subproject takes care of all matters related to building and compiling for s390x architecture.
+        leads:
+        - github: jschintag
+          name: "Jan Schintag"
+          company: IBM
+        - github: cfilleke
+          name: "Cheryl Fillekes"
+          company: IBM
+        - github: vamsikrishna-siddu
+          name: "vamsikrishna-siddu"
+          company: IBM
+        owners:
+        - https://raw.githubusercontent.com/kubevirt/kubevirt/main/OWNERS
+        - https://raw.githubusercontent.com/kubevirt/kubevirtci/main/OWNERS
+        - https://raw.githubusercontent.com/kubevirt/containerized-data-importer/main/OWNERS
       mission_statement: |
         SIG buildsystem takes care of all things building and automating for the KubeVirt project - they ensure new and existing contributors have a smooth contribution experience, i.o.w. contributors shouldn't have the feeling that they are wasting their time.
         This includes bazel, test automation and updates, also support of failing builds or test lanes in case of infrastructural or configuration problems.
@@ -201,6 +218,43 @@ sigs:
         teams:
         - name: kubevirt-community
           description: General Discussion
+      subprojects:
+      - name: ci-s390x
+        description: |
+          The ci-s390x subproject takes care of all matters related to CI for s390x architecture.
+          leads:
+          - github: jschintag
+            name: "Jan Schintag"
+            company: IBM
+          - github: cfilleke
+            name: "Cheryl Fillekes"
+            company: IBM
+          - github: vamsikrishna-siddu
+            name: "vamsikrishna-siddu"
+            company: IBM
+          - github: chandramerla
+            name: "Chandra Merla"
+            company: IBM
+        owners:
+        - https://raw.githubusercontent.com/kubevirt/project-infra/main/OWNERS
+workinggroups:
+    - dir: wg-arch-s390x
+      name: S390x architecture working group
+      mission_statement: |
+        WG ARCH s390x takes care of all things related to supporting s390x architecture on KubeVirt clusters.
+        This includes all build processes, also support of failing builds or test lanes.
+      label: wg-arch-s390x
+      leadership:
+        chairs:
+        - github: jschintag
+          name: "Jan Schintag"
+          company: IBM
+        - github: cfilleke
+          name: "Cheryl Fillekes"
+          company: IBM
+        - github: vamsikrishna-siddu
+          name: "vamsikrishna-siddu"
+          company: IBM
 usergroups:
     - dir: kubevirt-community
       name: KubeVirt Community

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -169,6 +169,16 @@ sigs:
         - https://raw.githubusercontent.com/kubevirt/kubevirt/main/OWNERS
         - https://raw.githubusercontent.com/kubevirt/kubevirtci/main/OWNERS
         - https://raw.githubusercontent.com/kubevirt/containerized-data-importer/main/OWNERS
+      - name: arch-arm
+        description: |
+          The arch-arm subproject takes care of all matters related to building and compiling for arm architecture.
+        leads:
+        - github: zhlhahaha
+          name: "Howard Zhang"
+          company: ARM
+        owners:
+        - https://raw.githubusercontent.com/kubevirt/kubevirt/main/OWNERS
+        - https://raw.githubusercontent.com/kubevirt/kubevirtci/main/OWNERS
       mission_statement: |
         SIG buildsystem takes care of all things building and automating for the KubeVirt project - they ensure new and existing contributors have a smooth contribution experience, i.o.w. contributors shouldn't have the feeling that they are wasting their time.
         This includes bazel, test automation and updates, also support of failing builds or test lanes in case of infrastructural or configuration problems.
@@ -237,6 +247,15 @@ sigs:
             company: IBM
         owners:
         - https://raw.githubusercontent.com/kubevirt/project-infra/main/OWNERS
+      - name: ci-arm
+        description: |
+          The ciarch-arm subproject takes care of all matters related to CI for arm architecture.
+        leads:
+        - github: zhlhahaha
+          name: "Howard Zhang"
+          company: ARM
+        owners:
+        - https://raw.githubusercontent.com/kubevirt/project-infra/main/OWNERS
 workinggroups:
     - dir: wg-arch-s390x
       name: S390x architecture working group
@@ -255,6 +274,17 @@ workinggroups:
         - github: vamsikrishna-siddu
           name: "vamsikrishna-siddu"
           company: IBM
+    - dir: wg-arch-arm
+      name: ARM architecture working group
+      mission_statement: |
+        WG ARCH ARM takes care of all things related to supporting ARM architecture on KubeVirt clusters.
+        This includes all build processes, also support of failing builds or test lanes.
+      label: wg-arch-arm
+      leadership:
+        chairs:
+        - github: zhlhahaha
+          name: "Howard Zhang"
+          company: ARM
 usergroups:
     - dir: kubevirt-community
       name: KubeVirt Community

--- a/wg-arch-arm/charter.md
+++ b/wg-arch-arm/charter.md
@@ -1,0 +1,33 @@
+# WG ARM architecture Charter
+
+## Scope
+
+The ARM architecture working group takes care of all things related to supporting ARM architecture on KubeVirt clusters.
+This includes all build processes, also support of failing builds or test lanes.
+
+## Governance
+
+### Stakeholder SIGs
+
+#### sig-buildsystem
+
+subprojects:
+* arch-arm
+
+#### sig-ci
+
+subprojects:
+* arch-arm
+
+### Roles and responsibilities
+
+#### Chairs
+- @zhlhahaha
+
+#### Subproject leads
+
+##### sig-buildsystem
+- @zhlhahaha
+
+##### sig-ci
+- @zhlhahaha

--- a/wg-arch-s390x/charter.md
+++ b/wg-arch-s390x/charter.md
@@ -1,0 +1,39 @@
+# WG S390x architecture Charter
+
+## Scope
+
+The S390x architecture working group takes care of all things related to supporting s390x architecture on KubeVirt clusters.
+This includes all build processes, also support of failing builds or test lanes.
+
+## Governance
+
+### Stakeholder SIGs
+
+#### sig-buildsystem
+
+subprojects:
+* arch-s390x
+
+#### sig-ci
+
+subprojects:
+* arch-s390x
+
+### Roles and responsibilities
+
+#### Chairs
+- @jschintag
+- @cfilleke
+- @vamsikrishna-siddu
+
+#### Subproject leads
+##### sig-buildsystem
+- @jschintag
+- @cfilleke
+- @vamsikrishna-siddu
+
+##### sig-ci
+- @jschintag
+- @cfilleke
+- @vamsikrishna-siddu
+- @chandramerla


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

PR #301 added the wg-TEMPLATE as a starting point for creating working groups.

This PR adds two initial wg-arch working groups:
* wg-arch-s390x
* wg-arch-arm
to define chairs and leads on S390x and ARM.

Also it defines subprojects in sig-buildsystem and sig-ci, so that arch wg members can own code.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
