### PR TITLE
sig-compute: Introduce instancetype sub project

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -44,6 +44,23 @@ sigs:
             - https://raw.githubusercontent.com/kubevirt/csi-driver/master/OWNERS
             - https://raw.githubusercontent.com/kubevirt/kubevirt-tekton-tasks/main/OWNERS
             - https://raw.githubusercontent.com/kubevirt/kubectl-virt-plugin/main/OWNERS
+        - name: instancetype
+          description: The instance type and preference CRDs, APIs and feature set.
+          leads:
+            - github: lyarwood
+              name: "Lee Yarwood"
+              company: Red Hat
+            - github: 0xFelix
+              name: "Felix Matouschek"
+              company: Red Hat
+          owners:
+            - https://raw.githubusercontent.com/kubevirt/kubevirt/main/pkg/instancetype/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt/main/tests/instancetype/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt/main/tests/libinstancetype/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt/main/pkg/virt-operator/resource/generate/components/data/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt/main/staging/src/kubevirt.io/api/instancetype/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt/main/pkg/virtctl/create/instancetype/OWNERS
+            - https://raw.githubusercontent.com/kubevirt/kubevirt/main/pkg/virtctl/create/preference/OWNERS
     - dir: sig-documentation
       name: documentation
       subprojects:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR breaks the instance type feature out into a sub project [1] within the compute SIG.

The aim being to delegate ownership to individuals working in this area in an effort to help drive the API and overall feature towards v1 and GA. 

As sub projects have yet to be fully utilised within KubeVirt this PR also serves as a way to test out their use within the project given recent attempts to redefine and introduce working groups etc.

[1] https://github.com/kubernetes/community/blob/master/governance.md#subprojects

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The associated OWNER_ALIASES changes are provided by https://github.com/kubevirt/kubevirt/pull/12062 that will need to land first ahead of this change for the paths listed under `owners` to be valid.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
