### PR TITLE
membership, policy: add SIG, WG and subproject roles

### DIFF
--- a/membership_policy.md
+++ b/membership_policy.md
@@ -132,9 +132,11 @@ The following apply to the part of project for which one would be an approver in
 
 ## Special Interest Group (SIG) Chair
 
+The KubeVirt project is organized primarily into SIGs, each with a common purpose of advancing the project with respect to a specific topic, such as Networking or Storage. A SIG Chair is required to help guide and coordinate the SIG. 
+
 ### Requirements
 
-* Active reviewer for SIG matters for at least three months
+* Active reviewer for SIG matters for at least 3 months
 * Track record of contributions to SIG matters
 * Advanced knowledge in SIG subject
 
@@ -148,10 +150,10 @@ The following apply to the part of project for which one would be an approver in
 * Operates the SIG
   * Updates charter when required
   * Updates sigs.yaml SIG entry
-* Communicates and coordinates
-  * With sponsored WGs,
-  * With other SIGs, and
-  * The broader community
+* Communicates and coordinates:
+  * with sponsored WGs
+  * with other SIGs
+  * to the broader community
 * Claims approver rights in scope, i.e. by
   * Creating a sig-approver group in `OWNERS_ALIASES`,
   * Adding a reference to the above in an `OWNERS` file 
@@ -159,9 +161,11 @@ The following apply to the part of project for which one would be an approver in
 
 ## SIG Subproject Lead
 
+Specific work efforts within SIGs can be divided into subprojects. A SIG Subproject Lead is required to help guide and coordinate the subproject.  
+
 ### Requirements
 
-* Active reviewer for subproject matters for at least three months
+* Active reviewer for subproject matters for at least 3 months
 * Track record of contributions to subproject matters
 * Advanced knowledge in subproject scope
 
@@ -179,9 +183,11 @@ The following apply to the part of project for which one would be an approver in
 
 ## Working Group (WG) Chair
 
+Working groups are primarily used to facilitate topics of discussion that cross SIG lines. Working Group Chairs are required to help guide the working group and coordinate with SIG Chairs and the broader community.
+
 ### Requirements
 
-* Active reviewer for WG matters for at least three months
+* Active reviewer for WG matters for at least 3 months
 * Track record of contributions to WG matters
 * Advanced knowledge in WG scope
 

--- a/membership_policy.md
+++ b/membership_policy.md
@@ -8,7 +8,7 @@ This document outlines the various responsibilities of contributor roles in Kube
 | [Member](#member)                              | Active contributor in the community                                                                          | * Active contributor<br>* Sponsored by 2 members<br>* Multiple contributions to the project                          | KubeVirt GitHub org member           |
 | [Reviewer](#reviewer)                          | Review contributions from others                                                                             | * Member<br>* History of review and authorship in the project<br> * Sponsored by an approver                         | [OWNERS_ALIASES] file reviewer entry |
 | [Approver](#approver)                          | Approve accepting contributions                                                                              | * Reviewer<br>* Highly experienced<br> * Active reviewer & contributor to the project<br> * Sponsored by 2 approvers | [OWNERS_ALIASES] file approver entry |
-| [SIG Chair](#special-interest-group-sig-chair) | Lead a SIG aligned to the goals of the SIG charter                                                           | * sig-approver<br>* Highly experienced in SIG matters<br> * Active reviewer & contributor to the project             | [sigs.yaml] chair entry              |
+| [SIG Chair](#special-interest-group-sig-chair) | Lead a SIG aligned to the goals of the SIG charter                                                           | * Can be sig-approver<br>* Highly experienced in SIG matters<br> * Active reviewer & contributor to the project      | [sigs.yaml] chair entry              |
 | [SIG Subproject Lead](#sig-subproject-lead)    | Lead a subproject aligned to the goals of the SIG charter                                                    | * sig-reviewer<br>* Highly experienced in SIG subproject matters<br> * Active reviewer & contributor to the project  | [sigs.yaml] subproject leads entry   |
 | [WG Chair](#working-group-wg-chair)            | Lead a WG aligned to the goals of the WG charter                                                             | * Highly experienced in WG matters<br> * Active reviewer & contributor to the project                                | [sigs.yaml] WG chairs entry          |
 
@@ -147,6 +147,7 @@ The KubeVirt project is organized primarily into SIGs, each with a common purpos
   * Ensures that meeting notes are captured
 * Is a facilitator, i.e.
   * Advances SIG topics
+  * Approves & facilitates the creation of new subprojects
 * Operates the SIG
   * Updates charter when required
   * Updates sigs.yaml SIG entry
@@ -171,6 +172,7 @@ Specific work efforts within SIGs can be divided into subprojects. A SIG Subproj
 
 ### Responsibilities and privileges
 
+* Creates and maintains a subproject
 * Leads within subproject scope, i.e.
   * Sets technical direction,
   * Makes design decisions

--- a/membership_policy.md
+++ b/membership_policy.md
@@ -2,15 +2,15 @@
 
 This document outlines the various responsibilities of contributor roles in KubeVirt.
 
-| Role                                        | Responsibilities                                                                                             | Requirements                                                                                                        | Defined by                           |
-|---------------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| Contributor                                 | Adhere to the [KubeVirt code of conduct](https://github.com/kubevirt/community/blob/main/code-of-conduct.md) | Submit at least one pull request                                                                                    | Active GitHub account                |
-| Member                                      | Active contributor in the community                                                                          | * Active contributor<br>* Sponsored by 2 members<br>* Multiple contributions to the project                         | KubeVirt GitHub org member           |
-| Reviewer                                    | Review contributions from others                                                                             | * Member<br>* History of review and authorship in the project<br> * Sponsored by an approver                        | [OWNERS_ALIASES] file reviewer entry |
-| Approver                                    | Approve accepting contributions                                                                              | * Reviewer<br>* Highly experienced<br> * Active reviewer & contributor to the project<br>Sponsored by 2 approvers   | [OWNERS_ALIASES] file approver entry |
-| [SIG Chair](#sig-chair)                     | Lead a SIG aligned to the goals of the SIG charter                                                           | * sig-approver<br>* Highly experienced in SIG matters<br> * Active reviewer & contributor to the project            | [sigs.yaml] chair entry              |
-| [SIG Subproject Lead](#sig-subproject-lead) | Lead a subproject aligned to the goals of the SIG charter                                                    | * sig-reviewer<br>* Highly experienced in SIG subproject matters<br> * Active reviewer & contributor to the project | [sigs.yaml] subproject leads entry   |
-| [WG Chair](#wg-chair)                       | Lead a WG aligned to the goals of the WG charter                                                             | * Highly experienced in WG matters<br> * Active reviewer & contributor to the project                               | [sigs.yaml] WG chairs entry          |
+| Role                                           | Responsibilities                                                                                             | Requirements                                                                                                         | Defined by                           |
+|------------------------------------------------|--------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| [Contributor](#new-contributors)               | Adhere to the [KubeVirt code of conduct](https://github.com/kubevirt/community/blob/main/code-of-conduct.md) | Submit at least one pull request                                                                                     | Active GitHub account                |
+| [Member](#member)                              | Active contributor in the community                                                                          | * Active contributor<br>* Sponsored by 2 members<br>* Multiple contributions to the project                          | KubeVirt GitHub org member           |
+| [Reviewer](#reviewer)                          | Review contributions from others                                                                             | * Member<br>* History of review and authorship in the project<br> * Sponsored by an approver                         | [OWNERS_ALIASES] file reviewer entry |
+| [Approver](#approver)                          | Approve accepting contributions                                                                              | * Reviewer<br>* Highly experienced<br> * Active reviewer & contributor to the project<br> * Sponsored by 2 approvers | [OWNERS_ALIASES] file approver entry |
+| [SIG Chair](#special-interest-group-sig-chair) | Lead a SIG aligned to the goals of the SIG charter                                                           | * sig-approver<br>* Highly experienced in SIG matters<br> * Active reviewer & contributor to the project             | [sigs.yaml] chair entry              |
+| [SIG Subproject Lead](#sig-subproject-lead)    | Lead a subproject aligned to the goals of the SIG charter                                                    | * sig-reviewer<br>* Highly experienced in SIG subproject matters<br> * Active reviewer & contributor to the project  | [sigs.yaml] subproject leads entry   |
+| [WG Chair](#working-group-wg-chair)            | Lead a WG aligned to the goals of the WG charter                                                             | * Highly experienced in WG matters<br> * Active reviewer & contributor to the project                                | [sigs.yaml] WG chairs entry          |
 
 ## New contributors
 
@@ -52,7 +52,7 @@ Defined by: Member of the KubeVirt GitHub organization
 > [!IMPORTANT]
 > After the pull request against the org members section has been merged (see above), an invitation to the KubeVirt GitHub organization will be automatically sent to the new member. The new member needs to accept the invitation to receive member status.
 
-## Responsibilities and privileges
+### Responsibilities and privileges
 
   * Responsive to issues and PRs assigned to them
   * Responsive to mentions
@@ -75,7 +75,7 @@ Defined by: reviewers entry in an OWNERS file of the KubeVirt project.
 Note: Acceptance of contributions requires at least one approver in addition to the assigned reviewers.
 Reviewer Status is scoped to a part of the project.
 
-## Requirements
+### Requirements
 
 The following apply to the part of project for which one would be a reviewer in the [OWNERS_ALIASES] file.
 
@@ -130,44 +130,75 @@ The following apply to the part of project for which one would be an approver in
   * Mentor contributors and reviewers
   * May approve contributions for acceptance
 
-## SIG Chair
+## Special Interest Group (SIG) Chair
 
 ### Requirements
 
-* contributor
-* advanced knowledge in SIG subject
+* Active reviewer for SIG matters for at least three months
+* Track record of contributions to SIG matters
+* Advanced knowledge in SIG subject
 
 ### Responsibilities and privileges
 
-* is an organizer and facilitator
-* operates the SIG
-* communicates and coordinates with other SIGs, and the broader community
-* may claim approver rights in scope
+* Is an organizer, i.e.
+  * Ensures that SIG meetings are moderated
+  * Ensures that meeting notes are captured
+* Is a facilitator, i.e.
+  * Advances SIG topics
+* Operates the SIG
+  * Updates charter when required
+  * Updates sigs.yaml SIG entry
+* Communicates and coordinates
+  * With sponsored WGs,
+  * With other SIGs, and
+  * The broader community
+* Claims approver rights in scope, i.e. by
+  * Creating a sig-approver group in `OWNERS_ALIASES`,
+  * Adding a reference to the above in an `OWNERS` file 
+  * Adding an `owners` reference in sigs.yaml
 
 ## SIG Subproject Lead
 
 ### Requirements
 
-* contributor
-* advanced knowledge in subproject scope
+* Active reviewer for subproject matters for at least three months
+* Track record of contributions to subproject matters
+* Advanced knowledge in subproject scope
 
 ### Responsibilities and privileges
 
-* leads within subproject scope
-* is an active reviewer
-* may claim approver rights in scope
+* Leads within subproject scope, i.e.
+  * Sets technical direction,
+  * Makes design decisions
+  * Mentors other contributors
+  * Moderates technical discussions and decisions
+* Claims approver rights in scope, i.e. by
+  * Creating a subproject-approver group in `OWNERS_ALIASES`
+  * Adding a reference to the above in an `OWNERS` file
+  * Adding an `owners` reference in sigs.yaml
 
-## WG Chair
+## Working Group (WG) Chair
 
 ### Requirements
 
-* contributor
-* advanced knowledge in WG scope
+* Active reviewer for WG matters for at least three months
+* Track record of contributions to WG matters
+* Advanced knowledge in WG scope
 
 ### Responsibilities and privileges
 
-* is an organizer and facilitator
-* gives updates to respective sponsoring SIG Chairs
+* Is an organizer, i.e.
+  * Ensures that WG meetings are moderated
+  * Ensures that meeting notes are captured
+* Is a facilitator, i.e.
+  * Advances exploration of the WG scope
+  * Fosters collaboration across SIG boundaries related to WG scope
+* Operates the WG
+  * Updates charter when required
+  * Updates sigs.yaml WG entry
+* Communicates and coordinates
+  * Gives updates to respective sponsoring SIG Chairs
+  * The broader community
 
 ## Inactive members
 

--- a/membership_policy.md
+++ b/membership_policy.md
@@ -2,13 +2,15 @@
 
 This document outlines the various responsibilities of contributor roles in KubeVirt.
 
-| Role  | Responsibilities                                                                                             | Requirements | Defined by                                                                                    |
-| ----- |--------------------------------------------------------------------------------------------------------------| ------------ |-----------------------------------------------------------------------------------------------|
-| Contributor | Adhere to the [KubeVirt code of conduct](https://github.com/kubevirt/community/blob/main/code-of-conduct.md) | Submit at least one pull request | Active GitHub account                                                                         |
-| Member | Active contributor in the community                                                                          | * Active contributor<br>* Sponsored by 2 members<br>* Multiple contributions to the project | KubeVirt GitHub org member                                                                    |
-| Reviewer | Review contributions from others                                                                             | * Member<br>* History of review and authorship in the project<br> * Sponsored by an approver | [OWNERS_ALIASES] file reviewer entry                                                          |
-| Approver| Approve accepting contributions                                                                              | * Reviewer<br>* Highly experienced<br> * Active reviewer & contributor to the project<br>Sponsored by 2 approvers| [OWNERS_ALIASES] file approver entry |
-
+| Role                                        | Responsibilities                                                                                             | Requirements                                                                                                        | Defined by                           |
+|---------------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| Contributor                                 | Adhere to the [KubeVirt code of conduct](https://github.com/kubevirt/community/blob/main/code-of-conduct.md) | Submit at least one pull request                                                                                    | Active GitHub account                |
+| Member                                      | Active contributor in the community                                                                          | * Active contributor<br>* Sponsored by 2 members<br>* Multiple contributions to the project                         | KubeVirt GitHub org member           |
+| Reviewer                                    | Review contributions from others                                                                             | * Member<br>* History of review and authorship in the project<br> * Sponsored by an approver                        | [OWNERS_ALIASES] file reviewer entry |
+| Approver                                    | Approve accepting contributions                                                                              | * Reviewer<br>* Highly experienced<br> * Active reviewer & contributor to the project<br>Sponsored by 2 approvers   | [OWNERS_ALIASES] file approver entry |
+| [SIG Chair](#sig-chair)                     | Lead a SIG aligned to the goals of the SIG charter                                                           | * sig-approver<br>* Highly experienced in SIG matters<br> * Active reviewer & contributor to the project            | [sigs.yaml] chair entry              |
+| [SIG Subproject Lead](#sig-subproject-lead) | Lead a subproject aligned to the goals of the SIG charter                                                    | * sig-reviewer<br>* Highly experienced in SIG subproject matters<br> * Active reviewer & contributor to the project | [sigs.yaml] subproject leads entry   |
+| [WG Chair](#wg-chair)                       | Lead a WG aligned to the goals of the WG charter                                                             | * Highly experienced in WG matters<br> * Active reviewer & contributor to the project                               | [sigs.yaml] WG chairs entry          |
 
 ## New contributors
 
@@ -128,6 +130,45 @@ The following apply to the part of project for which one would be an approver in
   * Mentor contributors and reviewers
   * May approve contributions for acceptance
 
+## SIG Chair
+
+### Requirements
+
+* contributor
+* advanced knowledge in SIG subject
+
+### Responsibilities and privileges
+
+* is an organizer and facilitator
+* operates the SIG
+* communicates and coordinates with other SIGs, and the broader community
+* may claim approver rights in scope
+
+## SIG Subproject Lead
+
+### Requirements
+
+* contributor
+* advanced knowledge in subproject scope
+
+### Responsibilities and privileges
+
+* leads within subproject scope
+* is an active reviewer
+* may claim approver rights in scope
+
+## WG Chair
+
+### Requirements
+
+* contributor
+* advanced knowledge in WG scope
+
+### Responsibilities and privileges
+
+* is an organizer and facilitator
+* gives updates to respective sponsoring SIG Chairs
+
 ## Inactive members
 
 [_Members are continuously active contributors in the community._](#member)
@@ -161,3 +202,4 @@ before being able to contribute effectively.
 
 [CNCF DevStats project]: https://kubevirt.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=w&var-metric=activity&var-repogroup_name=All&var-users=All
 [OWNERS_ALIASES]: https://github.com/kubevirt/kubevirt/tree/main/OWNERS_ALIASES
+[sigs.yaml]: ./sigs.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As a followup to #301 this PR adds roles:
* SIG chair
* SIG Subproject Lead
* WG chair

Fixes a couple of header size issues in existing parts along the way.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
