### PR TITLE
community,OWNERS: self nomination of dhiller as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 reviewers:
   - aburdenthehand
   - cwilkers
+  - dhiller
   - jean-edouard
   - jobbler
 


### PR DESCRIPTION
I hereby nominate myself as a reviewer for the `kubevirt/community` repository, with the long term goal of becoming an approver.

I currently am one of the [SIG CI chairs](https://github.com/kubevirt/community/blob/main/sig-list.md#special-interest-groups) and also one of the SIG buildsystem chairs. I am employed by Red Hat and [active in the KubeVirt community since 2019](https://github.com/search?q=org%3Akubevirt+author%3Adhiller&type=issues&s=created&o=asc).

I have a [history of contributions](https://github.com/search?q=repo%3Akubevirt%2Fcommunity+author%3Adhiller&type=pullrequests) to this repository, where the main focus has been
* documentation of automation, 
* community processes and
* automatic document generation for community matters.

I would like to be a reviewer so that I can help working on improving community documentation, processes and automation for the KubeVirt community.

> [!NOTE]
> I specifically will **not** do technical reviews of design proposals, since I see this as
> 1. way over my head and
> 2. a responsibility of the SIGs.

FYI @aburdenthehand @vladikr 
