### PR TITLE
Removing Alona, cwilkers, & jobbler from reviewer/approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,15 @@
 reviewers:
   - aburdenthehand
-  - cwilkers
   - dhiller
   - jean-edouard
-  - jobbler
 
 approvers:
   - aburdenthehand
-  - AlonaKaplan
-  - cwilkers
   - davidvossel
   - fabiand
+  - jean-edouard
   - rmohr
   - vladikr
-  - jean-edouard
 
 emeritus_approvers:
   - karmab # 10 july 2019
@@ -26,3 +22,5 @@ emeritus_approvers:
   - alosadagrande # April 2020
   - codificat # Jan 2022
   - mazzystr # Jan 2022
+  - AlonaKaplan # Sep 2024
+  - cwilkers # Sep 2024


### PR DESCRIPTION
Sadly @AlonaKaplan  @cwilkers  and @jobbler are no longer active in the project. It has been a bit over 6 months since their last contribution and we should remove them from our reviewer/approver list.

Thank you for your past contributions, and for your help in making this project what it is today. 

(Also minor housekeeping: moving jed to alphabetical order)

I'm using the same criteria that we apply for [project maintainers](https://github.com/kubevirt/community/blob/main/GOVERNANCE.md). As discussed in this PR, we should document a process and criteria for retiring reviewers and approvers.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
