### PR TITLE
design-proposals: Clean template and add feature lifecycle section

### DIFF
--- a/design-proposals/proposal-template.md
+++ b/design-proposals/proposal-template.md
@@ -1,43 +1,70 @@
+# Proposal Template Title
+
 This template is simply a guide. When making proposals, feel free to add and
 remove portions of this outline to best fit your specific case. There is no
 expectation that people strictly stick to this outline, but it is a good place
-to start. 
+to start.
 
-# Overview
+## Overview
+
 (Provide a brief overview of the topic)
 
 ## Motivation
+
 (Why this enhancement is important)
 
 ## Goals
+
 (The desired outcome)
 
 ## Non Goals
+
 (limitations to the scope of the design)
 
 ## Definition of Users
+
 (who is this feature set intended for)
 
 ## User Stories
+
 (list of user stories this design aims to solve)
 
 ## Repos
+
 (list of repose this design impacts)
 
-# Design
+## Design
+
 (This should be brief and concise. We want just enough to get the point across)
 
 ## API Examples
+
 (tangible API examples used for discussion)
 
 ## Scalability
+
 (overview of how the design scales)
 
 ## Update/Rollback Compatibility
+
 (does this impact update compatibility and how)
 
 ## Functional Testing Approach
+
 (an overview on the approaches used to functional test this design)
 
-# Implementation Phases
+## Implementation Phases
+
 (How/if this design will get broken up into multiple phases)
+
+## Feature lifecycle Phases
+
+(How and when will the feature progress through the Alpha, Beta and GA lifecycle phases)
+
+(Refer to https://github.com/kubevirt/community/blob/main/design-proposals/feature-lifecycle.md#releases for more details)
+
+### Alpha (v1.5.0)
+
+### Beta (v1.6.0)
+
+### GA (v1.7.0)


### PR DESCRIPTION
/cc @xpivarc
/cc @vladikr
/cc @EdDev

**What this PR does / why we need it**:

As discussed at the unconference for v1.5.0 [1] we should start documenting the expected lifecycle of a given feature within our design proposals before later moving this tracking to an issue.

This change cleans up the template, removing multiple top level headings, adding whitespace around headings and adds a final section defining the lifecycle of a feature.

[1] https://unconference.kubevirt.io/D62SngbSRXO1uhTAc8Ikqg#xpivarc-Feature-lifecycleFuture-of-proposals---1-1-1-1


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #286

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
