### PR TITLE
Updating orgs.yaml link in membership_policy.md

### DIFF
--- a/membership_policy.md
+++ b/membership_policy.md
@@ -42,7 +42,7 @@ Defined by: Member of the KubeVirt GitHub organization
     * Sponsors must have close interactions with the prospective member
     * Sponsors must be reviewers or approvers in any of the OWNERS files found in KubeVirt's repositories, for example, [this](https://github.com/kubevirt/kubevirt/blob/main/OWNERS_ALIASES) or [this one](https://github.com/kubevirt/project-infra/blob/main/OWNERS).
     * Sponsors should be from multiple member companies to demonstrate integration across community.
-  * Open a PR against the [org members section](https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/files/orgs.yaml#L22)
+  * Open a PR against the [org members section](https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml#L20)
     * Ensure your sponsors are @mentioned on the issue
     * Complete every item on the [checklist](membership_checklist.md)
     * Make sure that the list of contributions included is representative of your work on the project.


### PR DESCRIPTION
Tiny change.
The membership_policy.md was pointing to a symlink in the project-infra for the membership guidelines - the file was moved last year to its [own folder](https://github.com/kubevirt/project-infra/pull/2933).

Sending folks directly to the correct file instead of a symlink will lower a barrier to them joining the org.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
