### PR TITLE
sigs.yaml: fix indentation of ci-s390x subproject

### DIFF
--- a/sigs.yaml
+++ b/sigs.yaml
@@ -236,19 +236,19 @@ sigs:
       - name: ci-s390x
         description: |
           The ci-s390x subproject takes care of all matters related to CI for s390x architecture.
-          leads:
-          - github: jschintag
-            name: "Jan Schintag"
-            company: IBM
-          - github: cfilleke
-            name: "Cheryl Fillekes"
-            company: IBM
-          - github: vamsikrishna-siddu
-            name: "vamsikrishna-siddu"
-            company: IBM
-          - github: chandramerla
-            name: "Chandra Merla"
-            company: IBM
+        leads:
+        - github: jschintag
+          name: "Jan Schintag"
+          company: IBM
+        - github: cfilleke
+          name: "Cheryl Fillekes"
+          company: IBM
+        - github: vamsikrishna-siddu
+          name: "vamsikrishna-siddu"
+          company: IBM
+        - github: chandramerla
+          name: "Chandra Merla"
+          company: IBM
         owners:
         - https://raw.githubusercontent.com/kubevirt/project-infra/main/OWNERS
       - name: ci-arm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

/kind cleanup

Fixes indentation of `leads:` section below ci-390x subproject in sigs.yaml.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @aburdenthehand 
