### PR TITLE
Adding note to MAINTAINERS that Vasiliy is on temp leave

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,7 @@ The current Maintainers Group for the Kubevirt Project consists of:
 | [Roman Mohr](https://github.com/rmohr) | Google | |
 | [Fabian Deutsch](https://github.com/fabiand) | Red Hat | |
 | [Stu Gott](https://github.com/stu-gott) | Red Hat | |
-| [Vasiliy Ulyanov](https://github.com/vasiliy-ul) | SUSE | |
+| [Vasiliy Ulyanov](https://github.com/vasiliy-ul) | SUSE | _[On temporary leave](https://github.com/kubevirt/kubevirt/pull/13370)_ |
 | [Ryan Hallisey](https://github.com/rthallisey) | Nvidia | |
 | [Andrew Burden](https://github.com/aburdenthehand) | Red Hat | Community Facilitator |
 


### PR DESCRIPTION
Vasiliy is taking a temporary leave for personal reasons. This was communicated by him in https://github.com/kubevirt/kubevirt/pull/13370 but also to me in a 1x1 on slack. 

We will reconnect in February 2025 to discuss next steps. Until then, it seems prudent to make a note on our maintainers file.

@vasiliy-ul in case you see this. 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
