### PR TITLE
Nominating Alice and Lubo as KubeVirt maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,8 @@ The current Maintainers Group for the KubeVirt Project consists of:
 | [Vasiliy Ulyanov](https://github.com/vasiliy-ul) | SUSE | _[On temporary leave](https://github.com/kubevirt/kubevirt/pull/13370)_ |
 | [Ryan Hallisey](https://github.com/rthallisey) | Nvidia | |
 | [Andrew Burden](https://github.com/aburdenthehand) | Red Hat | Community Facilitator |
+| [Alice Frosi](https://github.com/alicefr) | Red Hat | |
+| [Ľuboslav Pivarč](https://github.com/xpivarc) | Red Hat | |
 
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
 


### PR DESCRIPTION
Nominating Alice and Lubo to become KubeVirt maintainers.

I think this is long overdue as both have long embodied the role of the [project maintainer](https://github.com/kubevirt/community/blob/main/GOVERNANCE.md#maintainer-responsibilities).

Both are heavily involved in guiding the project through thoughtful reviews and feature work, representing KubeVirt at conferences, community engagement, and through mentoring. They show great leadership and technical authority at both deep and broad levels.

@davidvossel @fabiand @rmohr @rthallisey @stu-gott @vladikr 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding Alice and Lubo as project maintainers
```
