### PR TITLE
sigs.yaml: add sig-compute meetings

### DIFF
--- a/sig-list.md
+++ b/sig-list.md
@@ -30,7 +30,7 @@ Each group's material is in its subdirectory in this project.
 
 | Name | Label [1] | Chairs [2] | Contact | Meetings |
 |------|-----------|------------|---------|----------|
-|[sig-compute](sig-compute/charter.md) |[sig/compute](https://github.com/kubevirt/kubevirt/labels/sig/compute) |<ol><li>[Itamar Holder](https://github.com/iholder101), Red Hat</li><li>[Jed Lejosne](https://github.com/jean-edouard), Red Hat</li></ol> |[Slack](kubevirt-dev)<br/> [Mailing List](https://groups.google.com/forum/#!forum/kubevirt-dev) |<ul></ul> |
+|[compute](sig-compute/charter.md) |[sig/compute](https://github.com/kubevirt/kubevirt/labels/sig/compute) |<ol><li>[Itamar Holder](https://github.com/iholder101), Red Hat</li><li>[Jed Lejosne](https://github.com/jean-edouard), Red Hat</li></ol> |[Slack](kubevirt-dev)<br/> [Mailing List](https://groups.google.com/forum/#!forum/kubevirt-dev) |<ul><li>KubeVirt Compute SIG Meeting: [ Wednesday at 2:30 PM UTC (weekly) ](https://zoom.us/j/98091854677)</li></ul> |
 |documentation |[sig/documentation](https://github.com/kubevirt/kubevirt/labels/sig/documentation) | | |<ul></ul> |
 |[storage](sig-storage/charter.md) |[sig/storage](https://github.com/kubevirt/kubevirt/labels/sig/storage) |<ol><li>[Alice Frosi](https://github.com/alicefr), Red Hat</li><li>[Michael Henriksen](https://github.com/mhenriks), Red Hat</li></ol> | |<ul><li>KubeVirt Storage SIG Meeting: [ Monday at 1:00 PM UTC (bimonthly) ](https://zoom.us/j/97050528531)</li></ul> |
 |testing |[sig/testing](https://github.com/kubevirt/kubevirt/labels/sig/testing) | | |<ul></ul> |

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1,5 +1,5 @@
 sigs:
-    - name: sig-compute
+    - name: compute
       dir: sig-compute
       label: sig/compute
       leadership:

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -10,6 +10,14 @@ sigs:
             - github: jean-edouard
               name: Jed Lejosne
               company: Red Hat
+      meetings:
+        - description: KubeVirt Compute SIG Meeting
+          day: Wednesday
+          time: 2:30 PM
+          tz: UTC
+          frequency: weekly
+          url: https://zoom.us/j/98091854677
+          archive_url: https://docs.google.com/document/d/1VTeHa-QxppNcDQbpoddrucBz1vXjxWB0JLARfS5Uuqs
       contact:
         slack: kubevirt-dev
         mailing_list: https://groups.google.com/forum/#!forum/kubevirt-dev


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds sig-compute meetings to sig.yaml.

Also, add the "sig-" prefix to sig names, like sig-network or sig-storage.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
sigs.yaml: add sig-compute meetings
```
