### PR TITLE
Moving dvossel to emeritus; updating current maintainers with roles

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,14 +4,13 @@ The current Maintainers Group for the KubeVirt Project consists of:
 
 | Name | Employer | Responsibilities |
 | ----------- | ------- | -------------------------------- |
-| [David Vossel](https://github.com/davidvossel) | Red Hat | |
-| [Vladik Romanovsky](https://github.com/vladikr) | Red Hat | |
-| [Roman Mohr](https://github.com/rmohr) | Google | |
-| [Fabian Deutsch](https://github.com/fabiand) | Red Hat | |
-| [Stu Gott](https://github.com/stu-gott) | Red Hat | |
-| [Ryan Hallisey](https://github.com/rthallisey) | Nvidia | |
+| [Vladik Romanovsky](https://github.com/vladikr) | Red Hat | Architecture and Enhancements |
+| [Roman Mohr](https://github.com/rmohr) | Google | Architecture and Security |
+| [Fabian Deutsch](https://github.com/fabiand) | Red Hat | Architecture and Outreach |
+| [Stu Gott](https://github.com/stu-gott) | Red Hat | Architecture and Compute |
+| [Ryan Hallisey](https://github.com/rthallisey) | Nvidia | Scale and Performance |
 | [Andrew Burden](https://github.com/aburdenthehand) | Red Hat | Community Facilitator |
-| [Ľuboslav Pivarč](https://github.com/xpivarc) | Red Hat | |
+| [Ľuboslav Pivarč](https://github.com/xpivarc) | Red Hat | Compute and Enhancements |
 
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
 
@@ -25,3 +24,5 @@ See [the project Governance](GOVERNANCE.md) for how maintainers are selected and
 | [Federico Gimenez](https://github.com/fgimenez) | 9 May, 2022 |
 | [Vasiliy Ulyanov](https://github.com/vasiliy-ul) | 6 April, 2025 |
 | [Alice Frosi](https://github.com/alicefr) | 1 June, 2025 |
+| [David Vossel](https://github.com/davidvossel) | 30 June, 2025 |
+


### PR DESCRIPTION
Sadly, David Vossel (@davidvossel) has left the project. David was a critical part of KubeVirt long before it joined the CNCF and was one of the first maintainers of the project. We wish him all the very best in his next pursuits.

I am also adding maintainer roles to fulfil CNCF obligations.

@fabiand @rmohr @stu-gott @vladikr @rthallisey @xpivarc 
Please review these updates and modify as required. 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
David Vossel moving to emeritus maintainer
```
