### PR TITLE
Removing dvossel and adding missing maintainers from community approver list

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,11 +6,13 @@ aliases:
 
   approvers:
   - aburdenthehand
-  - davidvossel
   - fabiand
   - jean-edouard
   - rmohr
+  - rthallisey
+  - stu-gott
   - vladikr
+  - xpivarc
 
   #
   # automation stuff residing in this repo also needs approvers and reviewers


### PR DESCRIPTION
David is no longer with the project, and it seems only right that the project maintainers have permissions to approve PRs in the community repo, since it is primarily concerned with shaping the processes and direction of the project. 

Modifying the approver list to match this. 

FYI @rthallisey @stu-gott @xpivarc in case you disagree :)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
