### PR TITLE
sig-compute: Update charter and introduce node and cluster subprojects

### DIFF
--- a/sig-compute/charter.md
+++ b/sig-compute/charter.md
@@ -2,23 +2,20 @@
 
 ## Scope
 
-SIG-compute's scope is enormous, and includes node configurations, live-migration,
-virtualization, and much more.  
+The scope of sig-compute is enormous, and includes node configurations,
+live-migration, virtualization, and much more.  
 
-In fact, currently sig-compute's scope captures the vast majority of the areas in the
-project, being the "default" sig for everything not directly related to the scope of other
-SIGs (such as storage and network).
-
-In the future we aim to break sig-compute into more sub-SIGs, which will be more granular
-and help define a concrete scope.
+In fact, currently sig-compute's scope captures the vast majority of the areas
+in the project, being the "default" sig for everything not directly related to
+the scope of other SIGs (such as storage and network).
 
 ### In scope
 
-Following topics are in-scope.
+Following topics are spread across a number of subprojects to help maintainers
+better focus their time and energy on specific areas of the codebase:
 
-We can use these topics as a base ground for thinking how to break sig-compute in the future.
+#### sig-compute-node
 
-#### Node
 - SELinux
 - Cgroups
 - TPM
@@ -27,23 +24,28 @@ We can use these topics as a base ground for thinking how to break sig-compute i
 - KSM
 - External kernel boot
 - seccomp
+- virt-launcher maintenance
 - node-labeller
-- and more
-
-#### Virtualization
-- virt-launcher
 - libvirt / QEMU configuration
 - CPU features
 - Dedicated CPUs
 - Hypervisor features (e.g. HyperV)
 - devices management: generic host devices interface, GPU and vGPU discovery configuration
-- and more
 
-#### Live-migration
+#### sig-compute-cluster
+
 - Migration policies
 - Migration configuration
 - Migration performance
-- and more
+- virt-{operator,controller,api} maintenance
+
+#### sig-compute-virtctl
+
+- virtctl maintenance
+
+#### sig-compute-instancetype
+
+- Instance type and preference graduation and maintenance
 
 ### Out of scope
 
@@ -55,6 +57,7 @@ This sig follows the Roles and Organization Management outlined in [OWNERS_ALIAS
 file.
 
 SIG chairs:
+
 - [@jean-edouard](https://github.com/jean-edouard)
 - [@iholder101](https://github.com/iholder101)
 


### PR DESCRIPTION
/sig compute
/cc @iholder101 
/cc @jean-edouard
/cc @vladikr 
/cc @xpivarc
/cc @enp0s3
/cc @fossedihelm
/cc @0xFelix

**What this PR does / why we need it**:

This change introduces two new subprojects to allow the broad scope of the SIG to be better subdivided and spread across the pool of willing and available maintainers.

The existing instance type and virtctl subprojects are also explicitly listed for the first time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
