### PR TITLE
Adding Itamar as project maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,7 @@ The current Maintainers Group for the KubeVirt Project consists of:
 | [Ryan Hallisey](https://github.com/rthallisey) | Nvidia | Scale and Performance |
 | [Andrew Burden](https://github.com/aburdenthehand) | Red Hat | Community Facilitator |
 | [Ľuboslav Pivarč](https://github.com/xpivarc) | Red Hat | Compute and Enhancements |
+| [Itamar Holder](https://github.com/iholder101) | Red Hat | Compute and Enhancements |
 
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
 


### PR DESCRIPTION
I am very pleased to nominate Itamar as a KubeVirt project maintainer.

Itamar has long done a great job within the community and with SIG-compute, and has stepped up a great deal in the last couple of years. He has demonstrated leadership across SIGs and in the community and has been a driver of key initiatives, particularly his involvement with the VEP process. He is also an important voice when it comes to reviews and feedback; critical, but also able to be flexible to take in other perspectives in order to arrive at the best solution. 

@fabiand @rmohr @rthallisey @xpivarc @stu-gott @vladikr 
(@iholder101)


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding Itamar Holder as project maintainer
```
