### PR TITLE
Adopt documentation-first approach for AI context

### DIFF
--- a/ai-contribution-policy.md
+++ b/ai-contribution-policy.md
@@ -73,11 +73,9 @@ acceptable and need not be changed to `Assisted-by`.
 Authors **MUST** still adhere to KubeVirt's Developer's Certificate of Origin
 (DCO) requirements and sign off commits.
 
-This will be aided through the use of the emerging
-[AGENT.md](https://ampcode.com/AGENT.md) standard with symlinks provided to the
-in project prompt configuration files of various agents. An example file will
-be created within the [`kubevirt/.github`](https://github.com/kubevirt/.github)
-repository for projects to use as a base.
+Disclosure requirements are documented in project contribution guidelines,
+making them discoverable by both human contributors and AI tools alike (see
+[Providing Context to AI Tools](docs/ai-tooling-guidelines.md)).
 
 ### Scope of Disclosure
 
@@ -205,6 +203,5 @@ repository](https://github.com/kubevirt/community)
 - [QEMU Code Provenance
   Policy](https://www.qemu.org/docs/master/devel/code-provenance.html#use-of-ai-content-generators)
 - [Ghostty AI Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md)
-- [AGENT.md](https://ampcode.com/AGENT.md)
 - [KubeVirt Developer's Certificate of
   Origin](https://github.com/kubevirt/kubevirt/blob/main/DCO)

--- a/docs/ai-tooling-guidelines.md
+++ b/docs/ai-tooling-guidelines.md
@@ -1,0 +1,56 @@
+# Providing Context to AI Tools
+
+## Documentation-First Approach
+
+KubeVirt adopts an agent-agnostic, documentation-first approach for providing
+context to AI tools. Project knowledge - contribution guidelines, coding
+patterns, architectural decisions, review policies - lives in standard
+documentation files readable by both humans and AI agents.
+
+This approach is preferred over maintaining agent-specific configuration files
+(e.g., vendor-specific prompt files or rule sets) for several reasons:
+
+- The community's expertise is in writing good documentation, not in
+  maintaining agentic configurations
+- Good documentation serves both humans and AI tools simultaneously
+- It avoids vendor lock-in to any specific AI tool or platform
+- It reduces maintenance burden by having a single source of truth
+
+## Repository Documentation Index
+
+Repositories SHOULD provide a documentation index file that serves as a table
+of contents, linking relevant documentation by topic. AI tools can load this
+single file to gain awareness of available project documentation and pull in
+specific files as needed for the task at hand.
+
+This pattern is adopted by other projects (e.g., Anthropic's
+[docs map](https://code.claude.com/docs/en/claude_code_docs_map.md)) and keeps
+project knowledge in a form that is useful regardless of which AI tool - or
+human - accesses it.
+
+Repository maintainers may choose to additionally maintain an `AGENTS.md`
+file, but it is strongly encouraged that it link to a documentation index or
+other form of pointers to human-first documentation rather than encoding
+project knowledge directly.
+
+## Separation of Documentation and Tool Configuration
+
+When integrating AI-powered tools (e.g., automated code review bots),
+repositories SHOULD maintain a clear separation between:
+
+- **Documentation** (agent-agnostic): project knowledge, coding patterns,
+  review guidelines, and contribution policies. These live in standard markdown
+  files and serve any reader - human or AI.
+- **Tool configuration** (vendor-specific): operational settings such as noise
+  control, review profiles, and file routing. These live in tool-specific
+  configuration files (e.g., `.coderabbit.yaml`) and control only tool
+  behavior.
+
+Tool configuration files SHOULD reference documentation files for
+project-specific context rather than duplicating knowledge inline.
+
+Repository-level tool configuration applies only to tools that the repository
+has officially adopted (e.g., CodeRabbit for automated code review).
+Repositories SHOULD NOT include configuration for tools that individual
+developers use locally (e.g., Claude Code, Cursor, OpenCode). The choice and
+configuration of local development tools is left to each contributor.


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces the `AGENTS.md`/vendor-specific prompt file approach with an agent-agnostic, documentation-first strategy for providing context to AI tools.

Repositories are encouraged to maintain a documentation index file linking existing docs by topic [1], keeping project knowledge in standard markdown that serves both humans and AI tools equally. A clear separation between agent-agnostic documentation and vendor-specific tool configuration is established, and local development tool choice is left to individual contributors.

[1] This pattern is adopted by other projects (e.g., Anthropic's [docs map](https://code.claude.com/docs/en/claude_code_docs_map.md)).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
