### PR TITLE
docs: add release notes contributor guide

### DIFF
--- a/contributors/guide/release-notes.md
+++ b/contributors/guide/release-notes.md
@@ -5,7 +5,7 @@ the PR description: a note for any user- or operator-visible change, or `NONE`
 if the change doesn't need one.
 
 Notes are extracted automatically at release
-time and assembled into the changelog, 
+time and assembled into the changelog,
 so a note should be in its final form by the time the PR is approved.
 
 ## Does my pull request need a release note?
@@ -41,7 +41,9 @@ label and blocks the merge until a note is provided.
 
 Release notes are categorized in the changelog using GitHub labels: add the
 `/kind` and `/sig` commands (for example `/kind enhancement`, `/sig compute`)
-in the `release-note-labels` part of the PR description.
+in the PR description, in a subsequent comment, or by using the GitHub `Labels`
+filter. See the [release procedure](https://github.com/kubevirt/kubevirt/blob/main/docs/release-procedure.md)
+for more on these labels.
 
 ### Breaking changes
 
@@ -83,5 +85,5 @@ for the full rules.
   `[PR #N][author]` automatically.
 
 A release note should make sense to someone reading the changelog without
-opening the PR. Browsing the notes of
+opening the PR. See the release notes of
 [recent releases](https://github.com/kubevirt/kubevirt/releases) for reference.

--- a/contributors/guide/release-notes.md
+++ b/contributors/guide/release-notes.md
@@ -1,0 +1,87 @@
+# Release Notes
+
+Pull requests in KubeVirt repositories may require a `release-note` block in
+the PR description: a note for any user- or operator-visible change, or `NONE`
+if the change doesn't need one.
+
+Notes are extracted automatically at release
+time and assembled into the changelog, 
+so a note should be in its final form by the time the PR is approved.
+
+## Does my pull request need a release note?
+
+Any user-visible or operator-visible change qualifies. This could be a:
+
+- Bug fix that affects observable behavior
+- New feature or enhancement
+- API, CLI flag, or configuration schema change
+- Behavioral or performance change
+- Deprecation or removal
+- Security fix (CVE)
+
+No release note (`NONE`) is required for tests, CI/build infrastructure,
+documentation, or bugs that were never present in a released version.
+
+## Applying a release note
+
+Fill in the `release-note` block in your pull request description:
+
+````
+```release-note
+Fixed a bug where live migration failed on nodes with SR-IOV network interfaces.
+```
+````
+
+> **_NOTE:_**
+> Keep the note to a single line. The release tooling extracts only the first
+> line after the opening fence.
+
+If the block is missing, Prow adds the `do-not-merge/release-note-label-needed`
+label and blocks the merge until a note is provided.
+
+Release notes are categorized in the changelog using GitHub labels: add the
+`/kind` and `/sig` commands (for example `/kind enhancement`, `/sig compute`)
+in the `release-note-labels` part of the PR description.
+
+### Breaking changes
+
+For changes that require operator action before or after upgrading, start the
+note with **"action required"**. Prow then applies the
+`release-note-action-required` label:
+
+````
+```release-note
+action required: The `featureGates.LiveMigration` field has been removed. Enable live
+migration via `spec.configuration.migrations` in the KubeVirt CR instead.
+```
+````
+
+### Changes without a release note
+
+Write `NONE` inside the block, or comment `/release-note-none` on the pull
+request. Either way, Prow applies the `release-note-none` label and the PR is
+skipped when the changelog is generated.
+
+### Backports
+
+Pull requests against release branches need their own release note: a brief,
+one-line statement of what the backport addresses, incorporated into the
+changelog when the next version is cut from that branch. See the
+[backporting policy](https://github.com/kubevirt/kubevirt/blob/main/docs/release-branch-backporting.md)
+for the full rules.
+
+## Writing good release notes
+
+- Write in the past tense: "Fixed" instead of "Fix", "Added" instead of "Add".
+- Write for users and operators, not developers — skip internal implementation
+  details.
+- Be specific: name the affected feature, workload type, API field, or
+  configuration option.
+- For action-required notes, include a call to action and link to
+  documentation explaining what the operator must do.
+- Don't include the PR number or your username — the tooling prepends
+  `[PR #N][author]` automatically.
+
+A release note should make sense to someone reading the changelog without
+opening the PR. Browsing the notes of
+[recent releases](https://github.com/kubevirt/kubevirt/releases) for reference.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Document the release-note block process: when a note is required, how to apply it in a PR, and how to write a good one.

This doc will become the target of the Prow release-note plugin's configurable guidelines URL ([kubevirt/project-infra#4189](https://github.com/kubevirt/project-infra/issues/4189)).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:

A few other homes were suggested in the issue (user-guide, kubevirt/kubevirt docs, sig-release). I went with this repo as a starting point since the plugin URL is a single global setting, linked from bot comments across many repos in the org.

This documentation follows the same pattern as the k8s release notes guide, which lives at [kubernetes/community/contributors/guide/release-notes.md](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md). That said, I'm happy to move it to another place.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
